### PR TITLE
fix 1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-ligo_compiler?=docker run --rm -v "$(PWD)":"$(PWD)" -w "$(PWD)" ligolang/ligo:1.2.0
+ligo_compiler?=docker run --rm -v "$(PWD)":"$(PWD)" -w "$(PWD)" ligolang/ligo:1.7.0
 # ^ Override this variable when you run make command by make <COMMAND> ligo_compiler=<LIGO_EXECUTABLE>
 # ^ Otherwise use default one (you'll need docker)
 PROTOCOL_OPT?=
@@ -44,20 +44,6 @@ compile: ## compile contracts
 clean: ## clean up
 	@rm -rf compiled
 
-deploy: deploy_deps deploy.js
-
-deploy.js:
-	@echo "Running deploy script\n"
-	@cd deploy && npm i && npm start
-
-deploy_deps:
-	@echo "Installing deploy script dependencies"
-	@cd deploy && npm install
-	@echo ""
-
-install: ## install dependencies
-	@$(ligo_compiler) install
-
 .PHONY: test
 test: ## run tests (SUITE=permit make test)
 ifndef SUITE
@@ -73,6 +59,3 @@ ifndef SUITE
 else
 	@$(call test,$(SUITE).test.mligo)
 endif
-
-lint: ## lint code
-	@npx eslint ./scripts --ext .ts

--- a/lib/fa2.1/data/approvals.jsligo
+++ b/lib/fa2.1/data/approvals.jsligo
@@ -41,7 +41,7 @@ export const decrease_approved_amount = (
   amount_: Amount.T
 ): T => {
   let balance_ = get_amount(approvals, from_, spender, token_id);
-  assert_with_error((balance_ >= amount_), Errors.ins_balance);
+  Assert.Error.assert((balance_ >= amount_), Errors.ins_balance);
   balance_ = abs(balance_ - amount_);
 
   return set_amount(approvals, from_, spender, token_id, balance_);

--- a/lib/fa2.1/data/ledger.jsligo
+++ b/lib/fa2.1/data/ledger.jsligo
@@ -72,7 +72,7 @@ export namespace Common_Asset {
 
   export const sub_to_val = (amount_: Amount.T, old_value: option<Amount.T>): Amount.T => {
     const value = balance_of(old_value);
-    assert_with_error(value >= amount_, Errors.ins_balance);
+    Assert.Error.assert(value >= amount_, Errors.ins_balance);
 
     return abs(value - amount_);
   };

--- a/lib/fa2.1/data/operators.jsligo
+++ b/lib/fa2.1/data/operators.jsligo
@@ -29,7 +29,7 @@ export const assert_authorisation = (
 };
 
 const assert_update_permission = (owner: owner): unit => {
-   assert_with_error(owner == Tezos.get_sender(), Errors.only_sender_manage_operators);
+   Assert.Error.assert(owner == Tezos.get_sender(), Errors.only_sender_manage_operators);
 };
 
 export const add_operator = (

--- a/lib/fa2.1/entrypoints/approve.jsligo
+++ b/lib/fa2.1/entrypoints/approve.jsligo
@@ -1,92 +1,95 @@
 #import "../data/errors.jsligo" "Errors"
+
 #import "../data/token.jsligo" "Token"
+
 #import "../data/approvals.jsligo" "Approvals"
+
 #import "../data/storage.jsligo" "Storage"
 
 type Storage = Storage.T;
 
-type approve =
-// @layout comb
-{
-  owner     : address;
-  spender   : address;
-  token_id  : Token.T;
-  old_value : nat;
-  new_value : nat;
+type approve = {
+    owner: address;
+    spender: address;
+    token_id: Token.T;
+    old_value: nat;
+    new_value: nat;
 };
 
 type approvals = list<approve>;
+
 export type T = approvals;
 
-
-type allowance_update_type =
-@layout("comb")
-{
-  owner     : address;
-  spender   : address;
-  token_id  : Token.T;
-  new_allowance : nat;
-  diff      : int;
+type allowance_update_type = {
+    owner: address;
+    spender: address;
+    token_id: Token.T;
+    new_allowance: nat;
+    diff: int;
 };
 
 type event_map_value = [nat, int];
+
 type event_map_key = [address, address, Token.T];
 
 const _approve = (approve: approve, approvals: Approvals.T): Approvals.T => {
-  const { owner, spender, token_id, old_value, new_value } = approve;
-  const amount = Approvals.get_amount(approvals, owner, spender, token_id);
-  assert_with_error(amount == old_value, Errors.unsafe_approval);
-  assert_with_error(owner == Tezos.get_sender(), Errors.not_owner);
-  return Approvals.set_amount(approvals, owner, spender, token_id, new_value);
+    const { owner, spender, token_id, old_value, new_value } = approve;
+    const amount = Approvals.get_amount(approvals, owner, spender, token_id);
+    Assert.Error.assert(amount == old_value, Errors.unsafe_approval);
+    Assert.Error.assert(owner == Tezos.get_sender(), Errors.not_owner);
+    return Approvals.set_amount(approvals, owner, spender, token_id, new_value);
 };
 
-export const approve = <A, L>(
-    to_approve: approvals,
-    storage: Storage<A, L>
-): [list<operation>, Storage<A, L>] => {
+export const approve = <A, L>(to_approve: approvals, storage: Storage<A, L>): [
+    list<operation>,
+    Storage<A, L>
+] => {
     let event_approvals: map<event_map_key, event_map_value> = Map.empty;
     let newApprovals: Approvals.T = Storage.get_approvals(storage);
     let finalOperations = list([]);
-
     for (const a of to_approve) {
         newApprovals = _approve(a, newApprovals);
-
         const key: event_map_key = [a.owner, a.spender, a.token_id];
-        const oldData: option<event_map_value> = Map.find_opt(key, event_approvals);
-
+        const oldData: option<event_map_value> =
+            Map.find_opt(key, event_approvals);
         let diff: int = 0;
         match(oldData) {
-        when(Some(data)): do { diff = data[1] + (a.new_value - a.old_value)};
-        when(None): do { diff = a.new_value - a.old_value };
-    };
+            when (Some(data)):
+                do { diff = data[1] + (a.new_value - a.old_value) }
+            when (None()):
+                do { diff = a.new_value - a.old_value }
+        };
         event_approvals = Map.add(key, [a.new_value, diff], event_approvals);
     }
-    let finalEventApprovals: list<operation> = Map.fold(
-        ([acc, [key, value]]: [list<operation>, [event_map_key, event_map_value]]) => {
-            if (value[1] != 0) {
-                const event_data: allowance_update_type = {
-                    owner: key[0],
-                    spender: key[1],
-                    token_id: key[2],
-                    new_allowance: value[0],
-                    diff: value[1]
-                };
-               const event_balance = Tezos.emit("%allowance_update", event_data);
-               return list([event_balance, ...acc]);
-            }
-            return acc;
-        },
-        event_approvals,
-        list([])
-    )
-
+    let finalEventApprovals: list<operation> =
+        Map.fold(
+            (
+                [acc, [key, value]]: [
+                    list<operation>,
+                    [event_map_key, event_map_value]
+                ]
+            ) => {
+                if (value[1] != 0) {
+                    const event_data: allowance_update_type = {
+                        owner: key[0],
+                        spender: key[1],
+                        token_id: key[2],
+                        new_allowance: value[0],
+                        diff: value[1]
+                    };
+                    const event_balance =
+                        Tezos.emit("%allowance_update", event_data);
+                    return list([event_balance, ...acc]);
+                }
+                return acc;
+            },
+            event_approvals,
+            list([])
+        )
     /** Reverse event list **/
-
-    for (const op of finalEventApprovals) {    
-      finalOperations = list([op, ...finalOperations]);
+    for (const op of finalEventApprovals) {
+        finalOperations = list([op, ...finalOperations]);
     }
-
     const newStorage = Storage.set_approvals(storage, newApprovals);
-
     return [finalOperations, newStorage];
 };

--- a/lib/fa2.1/entrypoints/balance_of.jsligo
+++ b/lib/fa2.1/entrypoints/balance_of.jsligo
@@ -1,58 +1,59 @@
 #import "../data/token.jsligo" "Token"
+
 #import "../data/amount.jsligo" "Amount"
+
 #import "../data/ledger.jsligo" "Ledger"
+
 #import "../data/storage.jsligo" "Storage"
 
 type Storage = Storage.T;
 
-type request = {
-   owner    : address;
-   token_id : Token.T;
+type request = { owner: address; token_id: Token.T; };
+
+type callback = { request: request; balance: Amount.T; };
+
+type balance_of = {
+    requests: list<request>;
+    callback: contract<list<callback>>;
 };
 
-type callback =
-// @layout comb
-{
-   request : request;
-   balance : Amount.T;
-};
-
-type balance_of = 
-// @layout comb
-{
-   requests : list<request>;
-   callback : contract<list<callback>>;
-};
 export type T = balance_of;
 
 type LedgerModule = Ledger.ledger_module;
 
 const get_balance_info = <A, L>(
-   storage : Storage<A, L>,
-   ledger_module  : LedgerModule<L>,
-   request : request
-) : callback => {
-   const { owner, token_id } = request;
-   Storage.assert_token_exist(storage, token_id);
-
-   return { request, balance : ledger_module.balance_of([ledger_module.data, owner, token_id]) };
+    storage: Storage<A, L>,
+    ledger_module: LedgerModule<L>,
+    request: request
+): callback => {
+    const { owner, token_id } = request;
+    Storage.assert_token_exist(storage, token_id);
+    return {
+        request,
+        balance: ledger_module.balance_of([ledger_module.data, owner, token_id])
+    };
 };
 
 export const balance_of = <A, L>(
-   balance: balance_of,
-   storage: Storage<A, L>,
-   ledgerModule: LedgerModule<L>
-) : [list<operation>, Storage<A, L>] => {
-   const { requests, callback } = balance;
-
-   return [list([
-      Tezos.transaction(
-         List.map(
-            (request) => get_balance_info(storage, ledgerModule, request),
-            requests
-         ),
-         (0 as tez),
-         callback
-      )
-   ]), storage];
+    balance: balance_of,
+    storage: Storage<A, L>,
+    ledgerModule: LedgerModule<L>
+): [list<operation>, Storage<A, L>] => {
+    const { requests, callback } = balance;
+    return [
+        list(
+            [
+                Tezos.Next.Operation.transaction(
+                    List.map(
+                        (request) =>
+                            get_balance_info(storage, ledgerModule, request),
+                        requests
+                    ),
+                    (0 as tez),
+                    callback
+                )
+            ]
+        ),
+        storage
+    ];
 };

--- a/lib/fa2.1/entrypoints/burn.jsligo
+++ b/lib/fa2.1/entrypoints/burn.jsligo
@@ -1,110 +1,104 @@
 #import "../data/amount.jsligo" "Amount"
+
 #import "../data/errors.jsligo" "Errors"
+
 #import "../data/ledger.jsligo" "Ledger"
+
 #import "../data/storage.jsligo" "Storage"
+
 #import "../data/token.jsligo" "Token"
+
 #import "../data/tokenMetadata.jsligo" "TokenMetadata"
+
 #import "./transfer.jsligo" "Transfer"
+
 #import "../data/approvals.jsligo" "Approvals"
 
 type Storage = Storage.T;
+
 type LedgerModule = Ledger.ledger_module;
 
-type BurnParam = {
-  from_      : address;
-  token_id   : Token.T;
-  amount     : Amount.T;
+type BurnParam = { from_: address; token_id: Token.T; amount: Amount.T; };
+
+type total_supply_update_type = {
+    token_id: Token.T,
+    new_total_supply: nat,
+    diff: int
 };
 
-type total_supply_update_type =
-@layout("comb")
-{
-  token_id: Token.T,
-  new_total_supply: nat,
-  diff: int
+type balance_event_data = {
+    owner: address,
+    token_id: nat,
+    new_balance: nat,
+    diff: int
 };
 
-type balance_event_data =
-@layout("comb")
-{
-  owner: address,
-  token_id: nat,
-  new_balance: nat,
-  diff: int
-};
-
-type allowance_update_type =
-@layout("comb")
-{
-  owner     : address;
-  spender   : address;
-  token_id  : Token.T;
-  new_allowance : nat;
-  diff      : int;
+type allowance_update_type = {
+    owner: address;
+    spender: address;
+    token_id: Token.T;
+    new_allowance: nat;
+    diff: int;
 };
 
 export type T = BurnParam;
 
-
 type Burn = BurnParam;
+
 export type T = BurnParam;
 
 export const burn = <A, L>(
-  burnParam: BurnParam,
-  storage: Storage<A, L>,
-  ledger: LedgerModule<L>
+    burnParam: BurnParam,
+    storage: Storage<A, L>,
+    ledger: LedgerModule<L>
 ): [list<operation>, Storage<A, L>] => {
-  let operations = list([]);
-  const { from_, token_id, amount } = burnParam;
-  
-  Storage.assert_token_exist(storage, token_id);
-
-  const approvals = Storage.get_approvals(storage);
-
-  const oldApprovals = Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
-
-  const authorizedApprovals = Transfer.authorize_transfer(storage, approvals, from_, token_id, amount);
-
-  const newApprovals = Approvals.get_amount(authorizedApprovals, from_, Tezos.get_sender(), token_id);
-
-  if (oldApprovals != newApprovals) {
-       const allowance_update: allowance_update_type = {
-           owner: from_,
-           spender: Tezos.get_sender(),
-           token_id: token_id,
-           new_allowance: newApprovals,
-           diff: newApprovals - oldApprovals;
-       };
-       const allowance_event_op = Tezos.emit("%allowance_update", allowance_update);
-       operations = list([allowance_event_op, ...operations]);
-   }
-  
-  const newLedger = Ledger.decrease_token_amount_for_user(ledger, from_, token_id, amount);
-  
-  let newStorage = Storage.set_approvals(storage, authorizedApprovals);
-  newStorage = Storage.set_ledger(newStorage, newLedger.data);
-
-  let oldSupply = Ledger.get_supply(ledger, token_id);
-  const balance = Ledger.get_for_user(ledger, from_, token_id);
-  const supply_update: total_supply_update_type =
-                {
-                   token_id: token_id,
-                   new_total_supply: abs(oldSupply-amount),
-                   diff: -amount,
-               };
-  const balance_update: balance_event_data =
-                {
-                   owner: from_,
-                   token_id: token_id,
-                   new_balance: abs(balance - amount),
-                   diff: -amount,
-               };
-  const event_balance = Tezos.emit("%balance_update", balance_update);
-  const event_supply = Tezos.emit("%total_supply_update", supply_update);
-
-  operations = list([event_supply, ...operations]);
-  operations = list([event_balance, ...operations]);
-
-  return [operations, newStorage];
+    let operations = list([]);
+    const { from_, token_id, amount } = burnParam;
+    Storage.assert_token_exist(storage, token_id);
+    const approvals = Storage.get_approvals(storage);
+    const oldApprovals =
+        Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
+    const authorizedApprovals =
+        Transfer.authorize_transfer(storage, approvals, from_, token_id, amount);
+    const newApprovals =
+        Approvals.get_amount(
+            authorizedApprovals,
+            from_,
+            Tezos.get_sender(),
+            token_id
+        );
+    if (oldApprovals != newApprovals) {
+        const allowance_update: allowance_update_type = {
+            owner: from_,
+            spender: Tezos.get_sender(),
+            token_id: token_id,
+            new_allowance: newApprovals,
+            diff: newApprovals - oldApprovals;
+        };
+        const allowance_event_op =
+            Tezos.emit("%allowance_update", allowance_update);
+        operations = list([allowance_event_op, ...operations]);
+    }
+    const newLedger =
+        Ledger.decrease_token_amount_for_user(ledger, from_, token_id, amount);
+    let newStorage = Storage.set_approvals(storage, authorizedApprovals);
+    newStorage = Storage.set_ledger(newStorage, newLedger.data);
+    let oldSupply = Ledger.get_supply(ledger, token_id);
+    const balance = Ledger.get_for_user(ledger, from_, token_id);
+    const supply_update: total_supply_update_type = {
+        token_id: token_id,
+        new_total_supply: abs(oldSupply - amount),
+        diff: -amount,
+    };
+    const balance_update: balance_event_data = {
+        owner: from_,
+        token_id: token_id,
+        new_balance: abs(balance - amount),
+        diff: -amount,
+    };
+    const event_balance = Tezos.emit("%balance_update", balance_update);
+    const event_supply = Tezos.emit("%total_supply_update", supply_update);
+    operations = list([event_supply, ...operations]);
+    operations = list([event_balance, ...operations]);
+    return [operations, newStorage];
 };
-

--- a/lib/fa2.1/entrypoints/export_ticket.jsligo
+++ b/lib/fa2.1/entrypoints/export_ticket.jsligo
@@ -1,151 +1,181 @@
 #import "../data/errors.jsligo" "Errors"
+
 #import "../data/token.jsligo" "Token"
+
 #import "../data/ledger.jsligo" "Ledger"
+
 #import "../data/storage.jsligo" "Storage"
+
 #import "../data/approvals.jsligo" "Approvals"
+
 #import "./transfer.jsligo" "Transfer"
 
 type Storage = Storage.T;
 
 type ExportedTicket = ticket<[Token.T, option<bytes>]>;
 
-type TicketToExport =
-   // @layout comb
-   {
-      from_    : address;
-      token_id : Token.T;
-      amount   : nat;
-   };
+type TicketToExport = { from_: address; token_id: Token.T; amount: nat; };
 
 type ExportTicketRequest = {
-  to_ : address;
-  ticketsToExport : list<TicketToExport>;
+    to_: address;
+    ticketsToExport: list<TicketToExport>;
 };
 
-type ExportTicketsTo = {
-   to_ : address;
-   ticketsToExport : list<ExportedTicket>;
-   };
+type ExportTicketsTo = { to_: address; ticketsToExport: list<ExportedTicket>; };
 
 type ExportTicketOperation = {
-  destination : option<address>;
-  requests : list<ExportTicketRequest>;
+    destination: option<address>;
+    requests: list<ExportTicketRequest>;
 };
 
-type balance_event_data =
-  @layout("comb")
-  {
+type balance_event_data = {
     owner: address,
     token_id: nat,
     new_balance: nat,
     diff: int
-  };
+};
 
-type allowance_update_type = 
-   @layout("comb")
-{
-   owner: address,
-   spender: address,
-   token_id: nat,
-   new_allowance: nat,
-   diff: int
+type allowance_update_type = {
+    owner: address,
+    spender: address,
+    token_id: nat,
+    new_allowance: nat,
+    diff: int
 };
 
 type ExportTicket = ExportTicketOperation;
+
 export type T = ExportTicket;
 
 type LedgerModule = Ledger.ledger_module;
 
 const create_ticket = <A, L>(
-   storage: Storage<A, L>,
-   ticketToExport : TicketToExport,
-   ledger: LedgerModule<L>
-) : [list<operation>, ExportedTicket, LedgerModule<L>, Storage<A, L>] => {
-   const { from_, token_id, amount } = ticketToExport;
-   let operations : list<operation> = list([]);
-
-   /** Allowance & Operator checks **/
-
-   Storage.assert_token_exist(storage, token_id);
-   const approvals = Storage.get_approvals(storage);
-
-   const oldApprovals = Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
-   const authorizedApprovals = Transfer.authorize_transfer(storage, approvals, from_, token_id, amount);
-   const newApprovals = Approvals.get_amount(authorizedApprovals, from_, Tezos.get_sender(), token_id);
-
-   if (oldApprovals != newApprovals) {
-       const allowance_update: allowance_update_type = {
-           owner: from_,
-           spender: Tezos.get_sender(),
-           token_id: token_id,
-           new_allowance: newApprovals,
-           diff: newApprovals - oldApprovals;
-       };
-       const allowance_event_op = Tezos.emit("%allowance_update", allowance_update);
-       operations = list([allowance_event_op, ...operations]);
-   }
-   const balance = Ledger.get_for_user(ledger, from_, token_id);
-   const balance_update: balance_event_data =
-                {
-                   owner: from_,
-                   token_id: token_id,
-                   new_balance: abs(balance - amount),
-                   diff: -amount,
-               };
-   const event_balance = Tezos.emit("%balance_update", balance_update);
-   operations = list([event_balance, ...operations]);
-   const newLedger = Ledger.decrease_token_amount_for_user(ledger, from_, token_id, amount);
-   let newStorage = Storage.set_approvals(storage, authorizedApprovals);
-   newStorage = Storage.set_ledger(newStorage, newLedger.data);
-   const ticket = Option.unopt_with_error(
-      Tezos.create_ticket([token_id, None()], amount),
-      Errors.cannot_create_ticket
-   );
-   return [operations, ticket, newLedger, newStorage];
+    storage: Storage<A, L>,
+    ticketToExport: TicketToExport,
+    ledger: LedgerModule<L>
+): [list<operation>, ExportedTicket, LedgerModule<L>, Storage<A, L>] => {
+    const { from_, token_id, amount } = ticketToExport;
+    let operations: list<operation> = list([]);
+    /** Allowance & Operator checks **/
+    Storage.
+    assert_token_exist(storage, token_id);
+    const approvals = Storage.get_approvals(storage);
+    const oldApprovals =
+        Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
+    const authorizedApprovals =
+        Transfer.authorize_transfer(storage, approvals, from_, token_id, amount);
+    const newApprovals =
+        Approvals.get_amount(
+            authorizedApprovals,
+            from_,
+            Tezos.get_sender(),
+            token_id
+        );
+    if (oldApprovals != newApprovals) {
+        const allowance_update: allowance_update_type = {
+            owner: from_,
+            spender: Tezos.get_sender(),
+            token_id: token_id,
+            new_allowance: newApprovals,
+            diff: newApprovals - oldApprovals;
+        };
+        const allowance_event_op =
+            Tezos.emit("%allowance_update", allowance_update);
+        operations = list([allowance_event_op, ...operations]);
+    }
+    const balance = Ledger.get_for_user(ledger, from_, token_id);
+    const balance_update: balance_event_data = {
+        owner: from_,
+        token_id: token_id,
+        new_balance: abs(balance - amount),
+        diff: -amount,
+    };
+    const event_balance = Tezos.emit("%balance_update", balance_update);
+    operations = list([event_balance, ...operations]);
+    const newLedger =
+        Ledger.decrease_token_amount_for_user(ledger, from_, token_id, amount);
+    let newStorage = Storage.set_approvals(storage, authorizedApprovals);
+    newStorage = Storage.set_ledger(newStorage, newLedger.data);
+    const ticket =
+        Option.value_with_error(
+            Errors.cannot_create_ticket,
+            Tezos.Next.Ticket.create([token_id, None()], amount)
+        );
+    return [operations, ticket, newLedger, newStorage];
 };
 
 export const export_tickets = <A, L>(
-   op : ExportTicket,
-   storage : Storage<A, L>,
-   ledger : LedgerModule<L>
-) : [list<operation>, Storage<A, L>] => {
-   let operations : list<operation> = list([]);
-   let finalOperations = list([]);
-   let newLedger = ledger;
-   let finalStorage = storage;
-
-   if (Option.is_none(op.destination)) {
-   for (const request of op.requests) {
-      for (const tk of request.ticketsToExport) {
-         const [newOps, ticket, updatedLedger, newStorage] = create_ticket(storage, tk, newLedger);
-         newLedger = updatedLedger;
-         operations = list([...newOps, ...operations]);
-         const ticketReceiver: contract<ExportedTicket> = Tezos.get_contract_with_error(request.to_, Errors.invalid_destination);
-         operations = list([Tezos.transaction(ticket, 0tez, ticketReceiver), ...operations]);
-         finalStorage = newStorage;
-      }
-   }
-   }
-   if (Option.is_some(op.destination)) {
-      for (const request of op.requests) {
-         for (const tk of request.ticketsToExport) {
-            const [newOps, ticket, updatedLedger, newStorage] = create_ticket(storage, tk, newLedger);
-            newLedger = updatedLedger;
-            operations = list([...newOps, ...operations]);
-            let ticketOps : list<ExportedTicket> = list([ticket]);
-            let finalTicketOps : list<ExportTicketsTo> = list([{to_: request.to_, ticketsToExport: ticketOps}]);
-            const ticketReceiver: contract<list<ExportTicketsTo>> = Tezos.get_contract_with_error(Option.unopt(op.destination), Errors.invalid_destination);
-            operations = list([Tezos.transaction(finalTicketOps, 0tez, ticketReceiver), ...operations]);
-            finalStorage = newStorage;
-         }
-      }
-   }
-
-   /** Reverse operations list **/
-
-   for (const op of operations) {    
-    finalOperations = list([op, ...finalOperations]);
-  }
-  
-   return [finalOperations, Storage.set_ledger(finalStorage, newLedger.data)];
+    op: ExportTicket,
+    storage: Storage<A, L>,
+    ledger: LedgerModule<L>
+): [list<operation>, Storage<A, L>] => {
+    let operations: list<operation> = list([]);
+    let finalOperations = list([]);
+    let newLedger = ledger;
+    let finalStorage = storage;
+    if (Option.is_none(op.destination)) {
+        for (const request of op.requests) {
+            for (const tk of request.ticketsToExport) {
+                const [newOps, ticket, updatedLedger, newStorage] =
+                    create_ticket(storage, tk, newLedger);
+                newLedger = updatedLedger;
+                operations = list([...newOps, ...operations]);
+                const ticketReceiver: contract<ExportedTicket> =
+                    Tezos.get_contract_with_error(
+                        request.to_,
+                        Errors.invalid_destination
+                    );
+                operations
+                = list(
+                      [
+                          Tezos.Next.Operation.transaction(
+                              ticket,
+                              0tez,
+                              ticketReceiver
+                          ),
+                          ...operations
+                      ]
+                  );
+                finalStorage = newStorage;
+            }
+        }
+    }
+    if (Option.is_some(op.destination)) {
+        for (const request of op.requests) {
+            for (const tk of request.ticketsToExport) {
+                const [newOps, ticket, updatedLedger, newStorage] =
+                    create_ticket(storage, tk, newLedger);
+                newLedger = updatedLedger;
+                operations = list([...newOps, ...operations]);
+                let ticketOps: list<ExportedTicket> = list([ticket]);
+                let finalTicketOps: list<ExportTicketsTo> =
+                    list([{ to_: request.to_, ticketsToExport: ticketOps }]);
+                const ticketReceiver: contract<list<ExportTicketsTo>> =
+                    Tezos.get_contract_with_error(
+                        Option.value_with_error(
+                            "Option is None",
+                            op.destination
+                        ),
+                        Errors.invalid_destination
+                    );
+                operations
+                = list(
+                      [
+                          Tezos.Next.Operation.transaction(
+                              finalTicketOps,
+                              0tez,
+                              ticketReceiver
+                          ),
+                          ...operations
+                      ]
+                  );
+                finalStorage = newStorage;
+            }
+        }
+    }
+    /** Reverse operations list **/
+    for (const op of operations) {
+        finalOperations = list([op, ...finalOperations]);
+    }
+    return [finalOperations, Storage.set_ledger(finalStorage, newLedger.data)];
 };

--- a/lib/fa2.1/entrypoints/import_ticket.jsligo
+++ b/lib/fa2.1/entrypoints/import_ticket.jsligo
@@ -1,7 +1,11 @@
 #import "../data/errors.jsligo" "Errors"
+
 #import "../data/token.jsligo" "Token"
+
 #import "../data/ledger.jsligo" "Ledger"
+
 #import "../data/storage.jsligo" "Storage"
+
 #import "../data/amount.jsligo" "Amount"
 
 type Storage = Storage.T;
@@ -9,104 +13,111 @@ type Storage = Storage.T;
 type imported_ticket = ticket<[Token.T, option<bytes>]>;
 
 type tickets_to_import_to = {
-    to_ : address;
-    tickets_to_import : list<imported_ticket>;
+    to_: address;
+    tickets_to_import: list<imported_ticket>;
 };
 
-type balance_event_data =
-  @layout("comb")
-  {
+type balance_event_data = {
     owner: address,
     token_id: nat,
     new_balance: nat,
     diff: int
-  };
-
-export type transaction =
-  @layout("comb")
-{
-    to_      : option<address>;
-    token_id : Token.T;
-    amount   : Amount.T;
 };
 
-export type transfer =
-  @layout("comb")
-{
-    from_ : option<address>;
-    txs   : list<transaction>;
+export type transaction = {
+    to_: option<address>;
+    token_id: Token.T;
+    amount: Amount.T;
 };
+
+export type transfer = { from_: option<address>; txs: list<transaction>; };
 
 type import_ticket = list<tickets_to_import_to>;
+
 export type T = import_ticket;
 
 type LedgerModule = Ledger.ledger_module;
 
-const make_transaction = (to_: option<address>, token_id: Token.T, amount: Amount.T): transaction => {
-    return { to_; token_id; amount };
-}
+const make_transaction = (
+    to_: option<address>,
+    token_id: Token.T,
+    amount: Amount.T
+): transaction => { return { to_; token_id; amount }; }
 
 const make_transfer = (from_: option<address>, txs: list<transaction>): transfer => {
     return { from_; txs };
 }
 
 // @inline
-const assert_ticketer_is_self_address = (ticketer : address) : unit =>
-    assert_with_error(Tezos.get_self_address() == ticketer, Errors.invalid_ticket);
+const assert_ticketer_is_self_address = (ticketer: address): unit =>
+    Assert.Error.assert(
+        Tezos.get_self_address() == ticketer,
+        Errors.invalid_ticket
+    );
 
 const import_ticket_to = <L>(
-    to_ : address,
-    imported_ticket : imported_ticket,
-    [transactions, ledger, operations] : [list<transaction>, LedgerModule<L>, list<operation>]
-) : [list<transaction>, LedgerModule<L>, list<operation>] => {
+    to_: address,
+    imported_ticket: imported_ticket,
+    [transactions, ledger, operations]: [
+        list<transaction>,
+        LedgerModule<L>,
+        list<operation>
+    ]
+): [list<transaction>, LedgerModule<L>, list<operation>] => {
     let operationsEvent = operations;
-    const [[ticketer, [[token_id, _data], amount]], _] = Tezos.read_ticket(imported_ticket);
+    const [[ticketer, [[token_id, _data], amount]], _] =
+        Tezos.Next.Ticket.read(imported_ticket);
     assert_ticketer_is_self_address(ticketer);
-    const newLedger = Ledger.increase_token_amount_for_user(ledger, to_, token_id, amount);
+    const newLedger =
+        Ledger.increase_token_amount_for_user(ledger, to_, token_id, amount);
     const transaction = make_transaction(Some(to_), token_id, amount);
     const balance = Ledger.get_for_user(ledger, to_, token_id);
-    const balance_update: balance_event_data =
-                {
-                   owner: to_,
-                   token_id: token_id,
-                   new_balance: balance + amount,
-                   diff: int(amount),
-               };
+    const balance_update: balance_event_data = {
+        owner: to_,
+        token_id: token_id,
+        new_balance: balance + amount,
+        diff: int(amount),
+    };
     const event_balance = Tezos.emit("%balance_update", balance_update);
     operationsEvent = list([event_balance, ...operationsEvent]);
     return [list([transaction, ...transactions]), newLedger, operationsEvent];
 };
 
 export const import_tickets_to = <L>(
-    tickets_to_import_to : tickets_to_import_to,
-    [transfers, ledger, operations] : [list<transfer>, LedgerModule<L>, list<operation>]
+    tickets_to_import_to: tickets_to_import_to,
+    [transfers, ledger, operations]: [
+        list<transfer>,
+        LedgerModule<L>,
+        list<operation>
+    ]
 ): [list<transfer>, LedgerModule<L>, list<operation>] => {
     const { to_, tickets_to_import } = tickets_to_import_to;
-    const [transaction, newLedger, events] = List.fold_left( ([r, t]) => import_ticket_to(to_, t, r), [list([]), ledger, operations], tickets_to_import );
+    const [transaction, newLedger, events] =
+        List.fold_left(
+            ([r, t]) => import_ticket_to(to_, t, r),
+            [list([]), ledger, operations],
+            tickets_to_import
+        );
     const transfer = make_transfer(None(), transaction);
-
     return [list([transfer, ...transfers]), newLedger, events];
 };
 
 export const import_tickets = <A, L>(
-    importTicket : import_ticket,
-    storage : Storage<A, L>,
+    importTicket: import_ticket,
+    storage: Storage<A, L>,
     ledger: LedgerModule<L>
-) : [list<operation>, Storage<A, L>] => {
+): [list<operation>, Storage<A, L>] => {
     let operations = list([]);
     let finalOperations = list([]);
-
-    const [_transactions, newLedger, events] = List.fold_left(
-        ([r, t]) => import_tickets_to(t, r),
-        [list([]), ledger, operations],
-        importTicket
-    );
-
-   /** Reverse operations list **/
-
-   for (const op of events) {    
-    finalOperations = list([op, ...finalOperations]);
-  }
-  
+    const [_transactions, newLedger, events] =
+        List.fold_left(
+            ([r, t]) => import_tickets_to(t, r),
+            [list([]), ledger, operations],
+            importTicket
+        );
+    /** Reverse operations list **/
+    for (const op of events) {
+        finalOperations = list([op, ...finalOperations]);
+    }
     return [finalOperations, Storage.set_ledger(storage, newLedger.data)];
 };

--- a/lib/fa2.1/entrypoints/lambda_export.jsligo
+++ b/lib/fa2.1/entrypoints/lambda_export.jsligo
@@ -1,140 +1,143 @@
 #import "../data/errors.jsligo" "Errors"
+
 #import "../data/token.jsligo" "Token"
+
 #import "../data/ledger.jsligo" "Ledger"
+
 #import "../data/storage.jsligo" "Storage"
+
 #import "../data/approvals.jsligo" "Approvals"
+
 #import "./transfer.jsligo" "Transfer"
 
 type Storage = Storage.T;
 
 type ExportedTicket = ticket<[Token.T, option<bytes>]>;
 
-type TicketToExport =
-   // @layout comb
-   {
-      from_    : address;
-      token_id : Token.T;
-      amount   : nat;
-   };
+type TicketToExport = { from_: address; token_id: Token.T; amount: nat; };
 
 type destination = (tickets: list<ExportedTicket>) => list<operation>;
 
-type ExportTicketsTo =
-   // @layout comb
-   {
-      ticketsToExport : list<TicketToExport>;
-      destination : destination;
-   };
+type ExportTicketsTo = {
+    ticketsToExport: list<TicketToExport>;
+    destination: destination;
+};
 
 type ExportTicket = ExportTicketsTo;
+
 export type T = ExportTicket;
 
 type ProxyParameters = {
-   tickets: list<ExportedTicket>,
-   action: (tickets: list<ExportedTicket>) => list<operation>
+    tickets: list<ExportedTicket>,
+    action: (tickets: list<ExportedTicket>) => list<operation>
 };
 
-type balance_event_data =
-  @layout("comb")
-  {
+type balance_event_data = {
     owner: address,
     token_id: nat,
     new_balance: nat,
     diff: int
-  };
+};
 
-type allowance_update_type = 
-   @layout("comb")
-{
-   owner: address,
-   spender: address,
-   token_id: nat,
-   new_allowance: nat,
-   diff: int
+type allowance_update_type = {
+    owner: address,
+    spender: address,
+    token_id: nat,
+    new_allowance: nat,
+    diff: int
 };
 
 type LedgerModule = Ledger.ledger_module;
 
 const create_ticket = <A, L>(
-   storage: Storage<A, L>,
-   ticketToExport : TicketToExport,
-   ledger: LedgerModule<L>
-) : [list<operation>, ExportedTicket, LedgerModule<L>, Storage<A, L>] => {
-   const { from_, token_id, amount } = ticketToExport;
-   
-   let operations : list<operation> = list([]);
-
-   /** Allowance & Operator checks **/
-
-   Storage.assert_token_exist(storage, token_id);
-   const approvals = Storage.get_approvals(storage);
-
-   const oldApprovals = Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
-   const authorizedApprovals = Transfer.authorize_transfer(storage, approvals, from_, token_id, amount);
-   const newApprovals = Approvals.get_amount(authorizedApprovals, from_, Tezos.get_sender(), token_id);
-
-   if (oldApprovals != newApprovals) {
-       const allowance_update: allowance_update_type = {
-           owner: from_,
-           spender: Tezos.get_sender(),
-           token_id: token_id,
-           new_allowance: newApprovals,
-           diff: newApprovals - oldApprovals;
-       };
-       const allowance_event_op = Tezos.emit("%allowance_update", allowance_update);
-       operations = list([allowance_event_op, ...operations]);
-   }
-   const balance = Ledger.get_for_user(ledger, from_, token_id);
-   const balance_update: balance_event_data =
-                {
-                   owner: from_,
-                   token_id: token_id,
-                   new_balance: abs(balance - amount),
-                   diff: -amount,
-               };
-   const event_balance = Tezos.emit("%balance_update", balance_update);
-   operations = list([event_balance, ...operations]);
-   const newLedger = Ledger.decrease_token_amount_for_user(ledger, from_, token_id, amount);
-   let newStorage = Storage.set_approvals(storage, authorizedApprovals);
-   newStorage = Storage.set_ledger(newStorage, newLedger.data);
-
-   const ticket = Option.unopt_with_error(
-      Tezos.create_ticket([token_id, None()], amount),
-      Errors.cannot_create_ticket
-   );
-   return [operations, ticket, newLedger, newStorage];
+    storage: Storage<A, L>,
+    ticketToExport: TicketToExport,
+    ledger: LedgerModule<L>
+): [list<operation>, ExportedTicket, LedgerModule<L>, Storage<A, L>] => {
+    const { from_, token_id, amount } = ticketToExport;
+    let operations: list<operation> = list([]);
+    /** Allowance & Operator checks **/
+    Storage.
+    assert_token_exist(storage, token_id);
+    const approvals = Storage.get_approvals(storage);
+    const oldApprovals =
+        Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
+    const authorizedApprovals =
+        Transfer.authorize_transfer(storage, approvals, from_, token_id, amount);
+    const newApprovals =
+        Approvals.get_amount(
+            authorizedApprovals,
+            from_,
+            Tezos.get_sender(),
+            token_id
+        );
+    if (oldApprovals != newApprovals) {
+        const allowance_update: allowance_update_type = {
+            owner: from_,
+            spender: Tezos.get_sender(),
+            token_id: token_id,
+            new_allowance: newApprovals,
+            diff: newApprovals - oldApprovals;
+        };
+        const allowance_event_op =
+            Tezos.emit("%allowance_update", allowance_update);
+        operations = list([allowance_event_op, ...operations]);
+    }
+    const balance = Ledger.get_for_user(ledger, from_, token_id);
+    const balance_update: balance_event_data = {
+        owner: from_,
+        token_id: token_id,
+        new_balance: abs(balance - amount),
+        diff: -amount,
+    };
+    const event_balance = Tezos.emit("%balance_update", balance_update);
+    operations = list([event_balance, ...operations]);
+    const newLedger =
+        Ledger.decrease_token_amount_for_user(ledger, from_, token_id, amount);
+    let newStorage = Storage.set_approvals(storage, authorizedApprovals);
+    newStorage = Storage.set_ledger(newStorage, newLedger.data);
+    const ticket =
+        Option.value_with_error(
+            Errors.cannot_create_ticket,
+            Tezos.Next.Ticket.create([token_id, None()], amount)
+        );
+    return [operations, ticket, newLedger, newStorage];
 };
 
 export const lambda_export = <A, L>(
-   exportTicket : ExportTicket,
-   storage : Storage<A, L>,
-   ledger : LedgerModule<L>
-) : [list<operation>, Storage<A, L>] => {
-   let finalOperations : list<operation> = list([]);
-   const { ticketsToExport, destination } = exportTicket;
-
-   const [tickets, newLedger, newStorage, newOperations] = List.fold_left(
-      ([[lt, l, s, ops], tk]) => {
-         const [ticketOps, ticket, updatedLedger, updatedStorage] = create_ticket(s, tk, l);
-         let combinedOps = list([...ops, ...ticketOps]);
-         return [list([ticket, ...lt]), updatedLedger, updatedStorage, combinedOps];
-      },
-      [list([]), ledger, storage, finalOperations],
-      ticketsToExport
-   );
-   
-   const operation = Tezos.transaction(
-      {
-         tickets,
-         action: destination
-      },
-      Tezos.get_amount(),
-      Option.unopt_with_error(
-         Tezos.get_contract_opt(storage.proxy),
-         Errors.invalid_proxy
-      )
-   );
-   finalOperations = list([operation, ...newOperations]);
-
-   return [finalOperations, Storage.set_ledger(newStorage, newLedger.data)];
+    exportTicket: ExportTicket,
+    storage: Storage<A, L>,
+    ledger: LedgerModule<L>
+): [list<operation>, Storage<A, L>] => {
+    let finalOperations: list<operation> = list([]);
+    const f = ([acc, tk]) => {
+        let [lt, l, s, ops] = acc;
+        const [ticketOps, ticket, updatedLedger, updatedStorage] =
+            create_ticket(s, tk, l);
+        let combinedOps = list([...ops, ...ticketOps]);
+        return [
+            List.cons(ticket, lt),
+            updatedLedger,
+            updatedStorage,
+            combinedOps
+        ];
+    };
+    const { ticketsToExport, destination } = exportTicket;
+    const [tickets, newLedger, newStorage, newOperations] =
+        List.fold_left(
+            f,
+            [list([]), ledger, storage, finalOperations],
+            ticketsToExport
+        );
+    const operation =
+        Tezos.Next.Operation.transaction(
+            { tickets, action: destination },
+            Tezos.get_amount(),
+            Option.value_with_error(
+                Errors.invalid_proxy,
+                Tezos.get_contract_opt(storage.proxy)
+            )
+        );
+    finalOperations = list([operation, ...newOperations]);
+    return [finalOperations, Storage.set_ledger(newStorage, newLedger.data)];
 };

--- a/lib/fa2.1/entrypoints/mint.jsligo
+++ b/lib/fa2.1/entrypoints/mint.jsligo
@@ -1,106 +1,128 @@
 #import "../data/amount.jsligo" "Amount"
+
 #import "../data/errors.jsligo" "Errors"
+
 #import "../data/ledger.jsligo" "Ledger"
+
 #import "../data/storage.jsligo" "Storage"
+
 #import "../data/token.jsligo" "Token"
+
 #import "../data/tokenMetadata.jsligo" "TokenMetadata"
 
 type Storage = Storage.T;
+
 type LedgerModule = Ledger.ledger_module;
 
 type MintParam = {
-  to_         : address;
-  token_id    : Token.T;
-  amount      : Amount.T;
-  token_info  : option<map<string, bytes>>;
+    to_: address;
+    token_id: Token.T;
+    amount: Amount.T;
+    token_info: option<map<string, bytes>>;
 };
 
-type total_supply_update_type =
-@layout("comb")
-{
-  token_id: Token.T,
-  new_total_supply: nat,
-  diff: int
+type total_supply_update_type = {
+    token_id: Token.T,
+    new_total_supply: Amount.T,
+    diff: int
 };
 
-type balance_event_data =
-@layout("comb")
-{
-  owner: address,
-  token_id: nat,
-  new_balance: nat,
-  diff: int
+type balance_event_data = {
+    owner: address,
+    token_id: nat,
+    new_balance: nat,
+    diff: int
 };
 
 type metadata_update_type =
-@layout("comb")
-{
-  token_id: Token.T,
-  new_metadata: option<map<string, bytes>>
-};
+    @layout("comb")
+    { token_id: Token.T, new_metadata: option<map<string, bytes>> };
 
 type Mint = MintParam;
+
 export type T = MintParam;
 
 export const mint = <A, L>(
-  mint: Mint,
-  storage: Storage<A, L>,
-  ledger: LedgerModule<L>
+    mint: Mint,
+    storage: Storage<A, L>,
+    ledger: LedgerModule<L>
 ): [list<operation>, Storage<A, L>] => {
     let operations = list([]);
     let finalOperations = list([]);
-  // assert_with_error(storage.extension.admin == Tezos.get_sender(), Errors.not_admin);
-
-  let oldSupply = Ledger.get_supply(ledger, mint.token_id);
-  const balance = Ledger.get_for_user(ledger, mint.to_, mint.token_id);
-  const supply_update: total_supply_update_type =
-                {
-                   token_id: mint.token_id,
-                   new_total_supply: mint.amount+oldSupply,
-                   diff: int(mint.amount),
-               };
-  const balance_update: balance_event_data =
-                {
-                   owner: mint.to_,
-                   token_id: mint.token_id,
-                   new_balance: balance + mint.amount,
-                   diff: int(mint.amount),
-               };
-  const event_balance = Tezos.emit("%balance_update", balance_update);
-  const event_supply = Tezos.emit("%total_supply_update", supply_update);
-  let new_token_info = match (mint.token_info) {
-    when (Some(token_metadata)): do { return token_metadata; };
-    when (None): do { return Map.empty; };
-  };
-  let token_info = TokenMetadata.get_token_info(storage.token_metadata, mint.token_id);
-  let newTokenMetadata = TokenMetadata.set_token_info(storage.token_metadata, mint.token_id, token_info);
-  if (Map.size(token_info) == (0 as nat) && Map.size(new_token_info) == (0 as nat)) {
-    token_info = Option.unopt_with_error(mint.token_info, "Token info must be provided");
-  };
-  if(Map.size(new_token_info) > (0 as nat)) {
-    newTokenMetadata = TokenMetadata.set_token_info(storage.token_metadata, mint.token_id, new_token_info);
-    const metadata_event_data: metadata_update_type = {
-      token_id: mint.token_id,
-      new_metadata: mint.token_info
+    // assert_with_error(storage.extension.admin == Tezos.get_sender(), Errors.not_admin);
+    let oldSupply = Ledger.get_supply(ledger, mint.token_id);
+    const balance = Ledger.get_for_user(ledger, mint.to_, mint.token_id);
+    const supply_update: total_supply_update_type = {
+        token_id: mint.token_id,
+        new_total_supply: mint.amount + oldSupply,
+        diff: int(mint.amount),
+    };
+    const balance_update: balance_event_data = {
+        owner: mint.to_,
+        token_id: mint.token_id,
+        new_balance: balance + mint.amount,
+        diff: int(mint.amount),
+    };
+    const event_balance = Tezos.emit("%balance_update", balance_update);
+    const event_supply = Tezos.emit("%total_supply_update", supply_update);
+    let new_token_info =
+        match(mint.token_info) {
+            when (Some(token_metadata)):
+                do { return token_metadata; }
+            when (None()):
+                do { return Map.empty; }
+        };
+    let token_info =
+        TokenMetadata.get_token_info(storage.token_metadata, mint.token_id);
+    let newTokenMetadata =
+        TokenMetadata.set_token_info(
+            storage.token_metadata,
+            mint.token_id,
+            token_info
+        );
+    if (
+        Map.size(token_info) == (0 as nat)
+        && Map.size(new_token_info) == (0 as nat)
+    ) {
+        token_info
+        = Option.unopt_with_error(
+              mint.token_info,
+              "Token info must be provided"
+          );
+    };
+    if (Map.size(new_token_info) > (0 as nat)) {
+        newTokenMetadata
+        = TokenMetadata.set_token_info(
+              storage.token_metadata,
+              mint.token_id,
+              new_token_info
+          );
+        const metadata_event_data: metadata_update_type = {
+            token_id: mint.token_id,
+            new_metadata: mint.token_info
+        }
+        const metadata_event =
+            Tezos.emit("%token_metadata_update", { metadata_event_data });
+        operations = list([metadata_event, ...operations]);
     }
-    const metadata_event = Tezos.emit("%token_metadata_update", { metadata_event_data });
-    operations = list([metadata_event, ...operations]);
-  }
-  const newLedger = Ledger.increase_token_amount_for_user(ledger, mint.to_, mint.token_id, mint.amount);
-  operations = list([event_supply, ...operations]);
-  operations = list([event_balance, ...operations]);
-
-  /** Reverse operations list **/
-
-  for (const op of operations) {    
-    finalOperations = list([op, ...finalOperations]);
-  }
-  
-  return [
-    finalOperations,
-    Storage.set_ledger(
-      Storage.set_token_metadata(storage, newTokenMetadata),
-      newLedger.data
-    )
-  ];
+    const newLedger =
+        Ledger.increase_token_amount_for_user(
+            ledger,
+            mint.to_,
+            mint.token_id,
+            mint.amount
+        );
+    operations = list([event_supply, ...operations]);
+    operations = list([event_balance, ...operations]);
+    /** Reverse operations list **/
+    for (const op of operations) {
+        finalOperations = list([op, ...finalOperations]);
+    }
+    return [
+        finalOperations,
+        Storage.set_ledger(
+            Storage.set_token_metadata(storage, newTokenMetadata),
+            newLedger.data
+        )
+    ];
 };

--- a/lib/fa2.1/entrypoints/transfer.jsligo
+++ b/lib/fa2.1/entrypoints/transfer.jsligo
@@ -1,235 +1,353 @@
 #import "../data/token.jsligo" "Token"
+
 #import "../data/amount.jsligo" "Amount"
+
 #import "../data/approvals.jsligo" "Approvals"
+
 #import "../data/operators.jsligo" "Operators"
+
 #import "../data/ledger.jsligo" "Ledger"
+
 #import "../data/storage.jsligo" "Storage"
+
 #import "../data/errors.jsligo" "Errors"
 
 type storage = Storage.T;
 
-type atomic_trans =
-// @layout comb
-{
-   to_      : address;
-   amount   : Amount.T;
-   token_id : Token.T;
-};
+type atomic_trans = // @layout comb
+ { to_: address; amount: Amount.T; token_id: Token.T; };
 
-type transfer_from = {
-   from_ : address;
-   txs   : list<atomic_trans>;
-};
+type transfer_from = { from_: address; txs: list<atomic_trans>; };
 
-type balance_event_data =
-  @layout("comb")
-  {
+type balance_event_data = {
     owner: address,
     token_id: nat,
     new_balance: nat,
     diff: int
-  };
-
-type allowance_update_type = 
-   @layout("comb")
-{
-   owner: address,
-   spender: address,
-   token_id: nat,
-   new_allowance: nat,
-   diff: int
 };
 
-type transfer_event_type = 
-   @layout("comb")
-{
-   from_: address,
-   to_: address,
-   token_id: nat,
-   amount: nat
+type allowance_update_type = {
+    owner: address,
+    spender: address,
+    token_id: nat,
+    new_allowance: nat,
+    diff: int
+};
+
+type transfer_event_type = {
+    from_: address,
+    to_: address,
+    token_id: nat,
+    amount: nat
 };
 
 type transfer = list<transfer_from>;
+
 export type t = transfer;
 
 type ledger_module = Ledger.ledger_module;
 
 export const authorize_transfer = <A, L>(
-   storage: storage<A, L>,
-   approvals: Approvals.T,
-   from_: address,
-   token_id: Token.T,
-   amount: Amount.T
+    storage: storage<A, L>,
+    approvals: Approvals.T,
+    from_: address,
+    token_id: Token.T,
+    amount: Amount.T
 ): Approvals.T => {
-
-  if (from_ == Tezos.get_sender()) {
-    return approvals;
-  }
-
-  const current_allowance: nat = Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
-  
-  if (current_allowance > (0 as nat)) {
-    if (current_allowance >= amount) {
-      return Approvals.decrease_approved_amount(approvals, from_, Tezos.get_sender(), token_id, amount);
+    if (from_ == Tezos.get_sender()) {
+        return approvals;
     }
-  }
-
-   return match(Storage.get_operators(storage)) {
-      when(Some(operators)): do {
-         Operators.assert_authorisation(operators, from_, token_id);
-         return approvals;
-      };
-      when(None()): do {
-         failwith(Errors.insufficient_allowance);
-      };
-   };
+    const current_allowance: nat =
+        Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
+    if (current_allowance > (0 as nat)) {
+        if (current_allowance >= amount) {
+            return Approvals.decrease_approved_amount(
+                approvals,
+                from_,
+                Tezos.get_sender(),
+                token_id,
+                amount
+            );
+        }
+    }
+    return match(Storage.get_operators(storage)) {
+        when (Some(operators)):
+            do {
+                Operators.assert_authorisation(operators, from_, token_id);
+                return approvals;
+            }
+        when (None()):
+            do { failwith(Errors.insufficient_allowance); }
+    };
 };
 
 type event_map_key = [address, Token.T];
+
 type allowance_event_map_key = [address, address, Token.T];
+
 type event_map_value = [nat, int];
 
 const atomic_trans = <A, L>(
-   storage : storage<A, L>,
-   from_ : address,
-   [[ledger, approvals, operations, event_balance, event_allowance], transfer] : [[ledger_module<L>, Approvals.T, list<operation>, map<event_map_key, event_map_value>, map<allowance_event_map_key, event_map_value>], atomic_trans]
-): [ledger_module<L>, Approvals.T, list<operation>, map<event_map_key, event_map_value>, map<allowance_event_map_key, event_map_value>] => {
-   let operationsEvent = operations;
-   let event_balance_map: map<event_map_key, event_map_value> = event_balance;
-   let event_allowance_map: map<allowance_event_map_key, event_map_value> = event_allowance;
-
-   const { to_, token_id, amount } = transfer;
-   Storage.assert_token_exist(storage, token_id);
-
-   const oldApprovals = Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
-   const authorizedApprovals = authorize_transfer(storage, approvals, from_, token_id, amount);
-   const newApprovals = Approvals.get_amount(authorizedApprovals, from_, Tezos.get_sender(), token_id);
-   const balance_from = Ledger.get_for_user(ledger, from_, token_id);
-   const balance_to = Ledger.get_for_user(ledger, to_, token_id);
-
-   let diff_from: int = 0;
-   let diff_to: int = 0;
-   let diff_allowance: int = 0;
-   const key_from: event_map_key = [from_, token_id];
-   const key_to: event_map_key = [to_, token_id];
-   const key_allowance: allowance_event_map_key = [from_, Tezos.get_sender(), token_id];
-
-   const oldData_from: option<event_map_value> = Map.find_opt(key_from, event_balance_map);
-   const oldData_to: option<event_map_value> = Map.find_opt(key_to, event_balance_map);
-   const oldData_allowance: option<event_map_value> = Map.find_opt(key_allowance, event_allowance_map);
-   let new_balance_from: nat = abs(balance_from - amount);
-   let new_balance_to: nat = balance_to + amount;
-
-   match(oldData_from) {
-        when(Some(data)): do { diff_from = data[1] - amount;
-        event_balance_map = Map.update(key_from, Some([new_balance_from, diff_from]), event_balance_map)};
-        when(None): do { diff_from = - amount;
-        event_balance_map = Map.add(key_from, [new_balance_from, diff_from], event_balance_map); };
+    storage: storage<A, L>,
+    from_: address,
+    [[ledger, approvals, operations, event_balance, event_allowance], transfer]: [
+        [
+            ledger_module<L>,
+            Approvals.T,
+            list<operation>,
+            map<event_map_key, event_map_value>,
+            map<allowance_event_map_key, event_map_value>
+        ],
+        atomic_trans
+    ]
+): [
+    ledger_module<L>,
+    Approvals.T,
+    list<operation>,
+    map<event_map_key, event_map_value>,
+    map<allowance_event_map_key, event_map_value>
+] => {
+    let operationsEvent = operations;
+    let event_balance_map: map<event_map_key, event_map_value> = event_balance;
+    let event_allowance_map: map<allowance_event_map_key, event_map_value> =
+        event_allowance;
+    const { to_, token_id, amount } = transfer;
+    Storage.assert_token_exist(storage, token_id);
+    const oldApprovals =
+        Approvals.get_amount(approvals, from_, Tezos.get_sender(), token_id);
+    const authorizedApprovals =
+        authorize_transfer(storage, approvals, from_, token_id, amount);
+    const newApprovals =
+        Approvals.get_amount(
+            authorizedApprovals,
+            from_,
+            Tezos.get_sender(),
+            token_id
+        );
+    const balance_from = Ledger.get_for_user(ledger, from_, token_id);
+    const balance_to = Ledger.get_for_user(ledger, to_, token_id);
+    let diff_from: int = 0;
+    let diff_to: int = 0;
+    let diff_allowance: int = 0;
+    const key_from: event_map_key = [from_, token_id];
+    const key_to: event_map_key = [to_, token_id];
+    const key_allowance: allowance_event_map_key = [
+        from_,
+        Tezos.get_sender(),
+        token_id
+    ];
+    const oldData_from: option<event_map_value> =
+        Map.find_opt(key_from, event_balance_map);
+    const oldData_to: option<event_map_value> =
+        Map.find_opt(key_to, event_balance_map);
+    const oldData_allowance: option<event_map_value> =
+        Map.find_opt(key_allowance, event_allowance_map);
+    let new_balance_from: nat = abs(balance_from - amount);
+    let new_balance_to: nat = balance_to + amount;
+    match(oldData_from) {
+        when (Some(data)):
+            do {
+                diff_from = data[1] - amount;
+                event_balance_map
+                = Map.update(
+                      key_from,
+                      Some([new_balance_from, diff_from]),
+                      event_balance_map
+                  )
+            }
+        when (None()):
+            do {
+                diff_from = -amount;
+                event_balance_map
+                = Map.add(
+                      key_from,
+                      [new_balance_from, diff_from],
+                      event_balance_map
+                  );
+            }
     };
-
     match(oldData_to) {
-        when(Some(data)): do { diff_to = data[1] + amount;
-        event_balance_map = Map.update(key_to, Some([new_balance_to, diff_to]), event_balance_map);};
-        when(None): do { diff_to = int(amount);
-        event_balance_map = Map.add(key_to, [new_balance_to, diff_to], event_balance_map); };
+        when (Some(data)):
+            do {
+                diff_to = data[1] + amount;
+                event_balance_map
+                = Map.update(
+                      key_to,
+                      Some([new_balance_to, diff_to]),
+                      event_balance_map
+                  );
+            }
+        when (None()):
+            do {
+                diff_to = int(amount);
+                event_balance_map
+                = Map.add(key_to, [new_balance_to, diff_to], event_balance_map);
+            }
     };
-
-   if (oldApprovals != newApprovals) {
-       match(oldData_allowance) {
-        when(Some(data)): do { diff_allowance = data[1] + (newApprovals - oldApprovals);
-        event_allowance_map = Map.update(key_allowance, Some([newApprovals, diff_allowance]), event_allowance_map);};
-        when(None): do { diff_allowance = newApprovals - oldApprovals;
-         event_allowance_map = Map.add(key_allowance, [newApprovals, diff_allowance], event_allowance_map);};
+    if (oldApprovals != newApprovals) {
+        match(oldData_allowance) {
+            when (Some(data)):
+                do {
+                    diff_allowance = data[1] + (newApprovals - oldApprovals);
+                    event_allowance_map
+                    = Map.update(
+                          key_allowance,
+                          Some([newApprovals, diff_allowance]),
+                          event_allowance_map
+                      );
+                }
+            when (None()):
+                do {
+                    diff_allowance = newApprovals - oldApprovals;
+                    event_allowance_map
+                    = Map.add(
+                          key_allowance,
+                          [newApprovals, diff_allowance],
+                          event_allowance_map
+                      );
+                }
+        };
+    }
+    const transfer_event_data: transfer_event_type = {
+        from_: from_,
+        to_: to_,
+        token_id: token_id,
+        amount: amount
     };
-   }
-   const transfer_event_data: transfer_event_type =
-      {
-       from_: from_,
-       to_: to_,
-       token_id: token_id,
-       amount: amount
-   };
-   const transfer_event_op = Tezos.emit("%transfer_event", transfer_event_data);
-   operationsEvent = list([transfer_event_op, ...operationsEvent]);
-
-   const newLedger = Ledger.decrease_token_amount_for_user(ledger, from_, token_id, amount);
-
-   return [Ledger.increase_token_amount_for_user(newLedger, to_, token_id, amount), authorizedApprovals, operationsEvent, event_balance_map, event_allowance_map];
+    const transfer_event_op = Tezos.emit("%transfer_event", transfer_event_data);
+    operationsEvent = list([transfer_event_op, ...operationsEvent]);
+    const newLedger =
+        Ledger.decrease_token_amount_for_user(ledger, from_, token_id, amount);
+    return [
+        Ledger.increase_token_amount_for_user(newLedger, to_, token_id, amount),
+        authorizedApprovals,
+        operationsEvent,
+        event_balance_map,
+        event_allowance_map
+    ];
 };
 
 const transfer_from = <A, L>(
-   storage: storage<A, L>,
-   [[ledger, approvals, operations, event_balance, event_allowance], transfer] : [[ledger_module<L>, Approvals.T, list<operation>, map<event_map_key, event_map_value>, map<allowance_event_map_key, event_map_value>], transfer_from]
-): [ledger_module<L>, Approvals.T, list<operation>, map<event_map_key, event_map_value>, map<allowance_event_map_key, event_map_value>] => {
-   const { from_, txs } = transfer;
-   let currentOperations = operations;
-   let event_balance_map: map<event_map_key, event_map_value> = event_balance;
-   let event_allowance_map: map<allowance_event_map_key, event_map_value> = event_allowance;
-
-   return List.fold_left(atomic_trans(storage, from_), [ledger, approvals, currentOperations, event_balance_map, event_allowance_map], txs);
+    storage: storage<A, L>,
+    [[ledger, approvals, operations, event_balance, event_allowance], transfer]: [
+        [
+            ledger_module<L>,
+            Approvals.T,
+            list<operation>,
+            map<event_map_key, event_map_value>,
+            map<allowance_event_map_key, event_map_value>
+        ],
+        transfer_from
+    ]
+): [
+    ledger_module<L>,
+    Approvals.T,
+    list<operation>,
+    map<event_map_key, event_map_value>,
+    map<allowance_event_map_key, event_map_value>
+] => {
+    const { from_, txs } = transfer;
+    let currentOperations = operations;
+    let event_balance_map: map<event_map_key, event_map_value> = event_balance;
+    let event_allowance_map: map<allowance_event_map_key, event_map_value> =
+        event_allowance;
+    return List.fold_left(
+        atomic_trans(storage, from_),
+        [
+            ledger,
+            approvals,
+            currentOperations,
+            event_balance_map,
+            event_allowance_map
+        ],
+        txs
+    );
 }
 
 export const transfer = <A, L>(
-   transfer: transfer,
-   storage: storage<A, L>,
-   ledger: ledger_module<L>
+    transfer: transfer,
+    storage: storage<A, L>,
+    ledger: ledger_module<L>
 ): [list<operation>, storage<A, L>] => {
-   let operations = list([]);
-   let finalOperations = list([]);
-   let event_balance_map: map<event_map_key, event_map_value> = Map.empty;
-   let event_allowance_map: map<allowance_event_map_key, event_map_value> = Map.empty;
-
-   const approvals = Storage.get_approvals(storage);
-   const [newLedger, newApprovals, operationsEvent, event_balance, event_allowance] = List.fold_left(transfer_from(storage), [ledger, approvals, operations, event_balance_map, event_allowance_map ], transfer);
-
-   let newStorage = Storage.set_approvals(storage, newApprovals);
-   newStorage = Storage.set_ledger(newStorage, newLedger.data);
-
-   let balance_updates: list<operation> = Map.fold(
-      ([acc, [key, value]]: [list<operation>, [event_map_key, event_map_value]]) => {
-         if (value[1] != 0) {
-               const data: balance_event_data = 
-               {
-                  owner: key[0],
-                  token_id: key[1],
-                  new_balance: value[0],
-                  diff: value[1]
-               };
-               const event_balance = Tezos.emit("%balance_update", data);
-               return list([event_balance, ...acc]);
-         }
-         return acc;
-      },
-      event_balance,
-      list([])
-   )
-
-   let allowance_updates: list<operation> = Map.fold(
-      ([acc, [key, value]]: [list<operation>, [allowance_event_map_key, event_map_value]]) => {
-         if (value[1] != 0) {
-               const data: allowance_update_type = 
-               {
-                  owner: key[0],
-                    spender: key[1],
-                    token_id: key[2],
-                    new_allowance: value[0],
-                    diff: value[1]
-               };
-               const event_allowance_op = Tezos.emit("%allowance_update", data);
-               return list([event_allowance_op, ...acc]);
-         }
-         return acc;
-      },
-      event_allowance,
-      list([])
-   )
-
-  /** Reverse operations list **/
-
-  for (const op of operationsEvent) {    
-    finalOperations = list([op, ...finalOperations]);
-  }
-  finalOperations = list([...allowance_updates, ...finalOperations]);
-  finalOperations = list([...balance_updates, ...finalOperations]);
-   return [finalOperations, newStorage];
+    let operations = list([]);
+    let finalOperations = list([]);
+    let event_balance_map: map<event_map_key, event_map_value> = Map.empty;
+    let event_allowance_map: map<allowance_event_map_key, event_map_value> =
+        Map.empty;
+    const approvals = Storage.get_approvals(storage);
+    const [
+        newLedger,
+        newApprovals,
+        operationsEvent,
+        event_balance,
+        event_allowance
+    ] =
+        List.fold_left(
+            transfer_from(storage),
+            [
+                ledger,
+                approvals,
+                operations,
+                event_balance_map,
+                event_allowance_map
+            ],
+            transfer
+        );
+    let newStorage = Storage.set_approvals(storage, newApprovals);
+    newStorage = Storage.set_ledger(newStorage, newLedger.data);
+    let balance_updates: list<operation> =
+        Map.fold(
+            (
+                [acc, [key, value]]: [
+                    list<operation>,
+                    [event_map_key, event_map_value]
+                ]
+            ) => {
+                if (value[1] != 0) {
+                    const data: balance_event_data = {
+                        owner: key[0],
+                        token_id: key[1],
+                        new_balance: value[0],
+                        diff: value[1]
+                    };
+                    const event_balance = Tezos.emit("%balance_update", data);
+                    return list([event_balance, ...acc]);
+                }
+                return acc;
+            },
+            event_balance,
+            list([])
+        )
+    let allowance_updates: list<operation> =
+        Map.fold(
+            (
+                [acc, [key, value]]: [
+                    list<operation>,
+                    [allowance_event_map_key, event_map_value]
+                ]
+            ) => {
+                if (value[1] != 0) {
+                    const data: allowance_update_type = {
+                        owner: key[0],
+                        spender: key[1],
+                        token_id: key[2],
+                        new_allowance: value[0],
+                        diff: value[1]
+                    };
+                    const event_allowance_op =
+                        Tezos.emit("%allowance_update", data);
+                    return list([event_allowance_op, ...acc]);
+                }
+                return acc;
+            },
+            event_allowance,
+            list([])
+        )
+    /** Reverse operations list **/
+    for (const op of operationsEvent) {
+        finalOperations = list([op, ...finalOperations]);
+    }
+    finalOperations = list([...allowance_updates, ...finalOperations]);
+    finalOperations = list([...balance_updates, ...finalOperations]);
+    return [finalOperations, newStorage];
 };

--- a/lib/fa2.1/entrypoints/update.jsligo
+++ b/lib/fa2.1/entrypoints/update.jsligo
@@ -1,91 +1,97 @@
 #import "../data/errors.jsligo" "Errors"
+
 #import "../data/operators.jsligo" "Operators"
+
 #import "../data/ledger.jsligo" "Ledger"
+
 #import "../data/storage.jsligo" "Storage"
+
 #import "../data/token.jsligo" "Token"
 
 type Storage = Storage.T;
 
-type operator =
-// @layout comb
-{
-      owner    : address;
-      operator : address;
-      token_id : nat;
+type operator = { owner: address; operator: address; token_id: nat; };
+
+export type operator_update = {
+    owner: address;
+    operator: address;
+    token_id: Token.T;
+    is_operator: bool;
 };
 
-export type operator_update =
-@layout("comb")
-{
-    owner       : address;
-    operator    : address;
-    token_id    : Token.T;
-    is_operator : bool;
-};
-
-type operator_update_event =
-@layout("comb")
-{
-    sender         : address;
-    operator_update: list<operator_update>; 
+type operator_update_event = {
+    sender: address;
+    operator_update: list<operator_update>;
 };
 
 export type unit_update =
-| ["AddOperator", operator]
-| ["RemoveOperator", operator];
+    ["AddOperator", operator] | ["RemoveOperator", operator];
 
 type update_operators = list<unit_update>;
+
 export type T = update_operators;
 
 const _update_ops = (
-      [updates, operators] : [list<operator_update>, Operators.t],
-      update : unit_update
-) : [list<operator_update>, Operators.t] => {
-      return match(update) {
-            when(AddOperator(operator)): do {
-                  const { owner, operator, token_id } = operator;
-                  const newOperators = Operators.add_operator(operators, owner, operator, token_id);
-                  const updatedOp: operator_update = {
+    [updates, operators]: [list<operator_update>, Operators.t],
+    update: unit_update
+): [list<operator_update>, Operators.t] => {
+    return match(update) {
+        when (AddOperator(operator)):
+            do {
+                const { owner, operator, token_id } = operator;
+                const newOperators =
+                    Operators.add_operator(operators, owner, operator, token_id);
+                const updatedOp: operator_update = {
+                    owner,
+                    operator,
+                    token_id,
+                    is_operator: true
+                };
+                return [list([updatedOp, ...updates]), newOperators];
+            }
+        when (RemoveOperator(operator)):
+            do {
+                const { owner, operator, token_id } = operator;
+                const newOperators =
+                    Operators.remove_operator(
+                        operators,
                         owner,
                         operator,
-                        token_id,
-                        is_operator: true
-                  };
-                  return [list([updatedOp, ...updates]), newOperators];
-            };
-            when(RemoveOperator(operator)): do {
-                  const { owner, operator, token_id } = operator;
-                  const newOperators = Operators.remove_operator(operators, owner, operator, token_id);
-                  const updatedOp: operator_update = {
-                        owner,
-                        operator,
-                        token_id,
-                        is_operator: true
-                  };
-
-                  return [list([updatedOp, ...updates]), newOperators];
-            };
-      };
+                        token_id
+                    );
+                const updatedOp: operator_update = {
+                    owner,
+                    operator,
+                    token_id,
+                    is_operator: true
+                };
+                return [list([updatedOp, ...updates]), newOperators];
+            }
+    };
 };
 
 export const update_ops = <A, L>(
-      updates: update_operators,
-      storage: Storage<A, L>
-) : [list<operation>, Storage<A, L>] => {
-      const sender = Tezos.get_sender();
-      return match(Storage.get_operators(storage)) {
-            when(Some(operators)): do {
-                  const [newUpdates, newOperators] = List.fold_left(
+    updates: update_operators,
+    storage: Storage<A, L>
+): [list<operation>, Storage<A, L>] => {
+    const sender = Tezos.get_sender();
+    return match(Storage.get_operators(storage)) {
+        when (Some(operators)):
+            do {
+                const [newUpdates, newOperators] =
+                    List.fold_left(
                         ([acc, item]) => _update_ops(acc, item),
                         [list([]), operators],
                         updates
-                  );
-                  
-                  return [
-                        list([ Tezos.emit("%operator_update", { sender, newUpdates }) ]),
-                        Storage.set_operators(storage, newOperators)
-                  ];
-            };
-            when(None()): failwith(Errors.storage_has_no_operators);
-      };
+                    );
+                return [
+                    list(
+                        [Tezos.emit("%operator_update", { sender, newUpdates })]
+                    ),
+                    Storage.set_operators(storage, newOperators)
+                ];
+            }
+        when (None()):
+            failwith(Errors.storage_has_no_operators)
+    };
 };

--- a/lib/fa2/asset/extendable_multi_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.jsligo
@@ -113,7 +113,7 @@ export const decrease_token_amount_for_user = (
    [ledger, from_, token_id, amount_]: [ledger, address, nat, nat]
 ): ledger => {
    let balance_ = get_for_user([ledger, from_, token_id]);
-   assert_with_error((balance_ >= amount_), Errors.ins_balance);
+   Assert.Error.assert((balance_ >= amount_), Errors.ins_balance);
    balance_ = abs(balance_ - amount_);
    return set_for_user([ledger, from_, token_id, balance_])
 };
@@ -167,7 +167,7 @@ export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
       return ({ request: request, balance: balance_ })
    };
    const callback_param = List.map(get_balance_info, requests);
-   const operation = Tezos.transaction(Main(callback_param), 0mutez, callback);
+   const operation = Tezos.Next.Operation.transaction(Main(callback_param), 0mutez, callback);
    return [list([operation]), s]
 };
 

--- a/lib/fa2/asset/extendable_multi_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.mligo
@@ -102,7 +102,7 @@ let decrease_token_amount_for_user
   (amount_ : nat)
 : ledger =
   let balance_ = get_for_user ledger from_ token_id in
-  let () = assert_with_error (balance_ >= amount_) Errors.ins_balance in
+  let () = Assert.Error.assert (balance_ >= amount_) Errors.ins_balance in
   let balance_ = abs (balance_ - amount_) in
   let ledger = set_for_user ledger from_ token_id balance_ in
   ledger
@@ -121,9 +121,10 @@ let increase_token_amount_for_user
 // Storage
 let assert_token_exist (type a) (s : a storage) (token_id : nat) : unit =
   let _ =
-    Option.unopt_with_error
+    Option.value_with_error
+      Errors.undefined_token
       (Big_map.find_opt token_id s.token_metadata)
-      Errors.undefined_token in
+      in
   ()
 
 let set_ledger (type a) (s : a storage) (ledger : ledger) =
@@ -176,7 +177,7 @@ let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
      balance = balance_
     } in
   let callback_param = List.map get_balance_info requests in
-  let operation = Tezos.transaction (Main callback_param) 0mutez callback in
+  let operation = Tezos.Next.Operation.transaction (Main callback_param) 0mutez callback in
   ([operation] : operation list), s
 
 let update_operators (type a)

--- a/lib/fa2/asset/extendable_single_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.jsligo
@@ -105,7 +105,7 @@ export const decrease_token_amount_for_user = (
    amount_: nat
 ): ledger => {
    let tokens = get_for_user(ledger, from_);
-   const _ = assert_with_error(tokens >= amount_, Errors.ins_balance);
+   const _ = Assert.Error.assert(tokens >= amount_, Errors.ins_balance);
    tokens = abs(tokens - amount_);
    return update_for_user(ledger, from_, tokens)
 };
@@ -164,7 +164,7 @@ export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
       return { request: request, balance: balance_ }
    };
    const callback_param = List.map(get_balance_info, requests);
-   const operation = Tezos.transaction(Main(callback_param), 0mutez, callback);
+   const operation = Tezos.Next.Operation.transaction(Main(callback_param), 0mutez, callback);
    return [list([operation]), s]
 };
 

--- a/lib/fa2/asset/extendable_single_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.mligo
@@ -88,7 +88,7 @@ let decrease_token_amount_for_user
   (amount_ : nat)
 : ledger =
   let tokens = get_for_user ledger from_ in
-  let () = assert_with_error (tokens >= amount_) Errors.ins_balance in
+  let () = Assert.Error.assert (tokens >= amount_) Errors.ins_balance in
   let tokens = abs (tokens - amount_) in
   let ledger = update_for_user ledger from_ tokens in
   ledger
@@ -156,7 +156,7 @@ let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
      balance = balance_
     } in
   let callback_param = List.map get_balance_info requests in
-  let operation = Tezos.transaction (Main callback_param) 0mutez callback in
+  let operation = Tezos.Next.Operation.transaction (Main callback_param) 0mutez callback in
   ([operation] : operation list), s
 
 (**

--- a/lib/fa2/common/assertions.jsligo
+++ b/lib/fa2/common/assertions.jsligo
@@ -10,8 +10,8 @@
 */
 
 export const assert_update_permission = (owner: address): unit => {
-    return assert_with_error(
-        (owner == (Tezos.get_sender())),
+    return Assert.Error.assert(
+        (owner == Tezos.get_sender()),
         Errors.only_sender_manage_operators
     )
 }
@@ -19,7 +19,7 @@ export const assert_update_permission = (owner: address): unit => {
 /**
 * Check if the token id is already defined
 * @param token_metadata : bigmap of token definitions
-* @param token_id : the token id to test 
+* @param token_id : the token id to test
 */
 
 export const assert_token_exist = (
@@ -27,8 +27,8 @@ export const assert_token_exist = (
     token_id: nat
 ): unit => {
     const _ =
-        Option.unopt_with_error(
-            Big_map.find_opt(token_id, token_metadata),
-            Errors.undefined_token
+        Option.value_with_error(
+          Errors.undefined_token,
+          Big_map.find_opt(token_id, token_metadata)
         )
 };

--- a/lib/fa2/nft/extendable_nft.impl.jsligo
+++ b/lib/fa2/nft/extendable_nft.impl.jsligo
@@ -20,7 +20,7 @@ export type storage<T> = {
 
 type ret<T> = [list<operation>, storage<T>];
 
-const make_storage = (extension) =>
+const make_storage = <T>(extension: T) : storage<T> =>
    (
       {
          ledger: Big_map.empty,
@@ -57,7 +57,7 @@ export const assert_authorisation = (
 export const add_operator = (
    operators: operators,
    owner: address,
-   operator: address,
+   operator: operator,
    token_id: nat
 ): operators => {
    if (owner == operator) {
@@ -80,7 +80,7 @@ export const add_operator = (
 export const remove_operator = (
    operators: operators,
    owner: address,
-   operator: address,
+   operator: operator,
    token_id: nat
 ): operators => {
    if (owner == operator) {
@@ -108,12 +108,13 @@ export const remove_operator = (
 
 //  ledger
 export const is_owner_of = (ledger: ledger, token_id: nat, owner: address): bool => {
-   const current_owner = Option.unopt(Big_map.find_opt(token_id, ledger));
+   const current_owner = Option.value_with_error ("option is None", Big_map.find_opt(token_id, ledger));
    return (current_owner == owner)
 };
 
 export const assert_owner_of = (ledger: ledger, token_id: nat, owner: address): unit =>
-   assert_with_error(is_owner_of(ledger, token_id, owner), Errors.ins_balance);
+   Assert.Error.assert(is_owner_of(ledger, token_id, owner), Errors.ins_balance);
+
 
 export const transfer_token_from_user_to_user = (
    ledger: ledger,
@@ -171,7 +172,7 @@ export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
       return ({ request: request, balance: balance_ })
    };
    const callback_param = List.map(get_balance_info, requests);
-   const operation = Tezos.transaction(Main(callback_param), 0mutez, callback);
+   const operation = Tezos.Next.Operation.transaction(Main(callback_param), 0mutez, callback);
    return [list([operation]), s]
 };
 

--- a/lib/fa2/nft/extendable_nft.impl.mligo
+++ b/lib/fa2/nft/extendable_nft.impl.mligo
@@ -1,7 +1,6 @@
 [@public] #import "../common/assertions.jsligo" "Assertions"
 [@public] #import "../common/errors.mligo" "Errors"
 [@public] #import "../common/tzip12.datatypes.jsligo" "TZIP12"
-[@public] #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
 [@public] #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 type ledger = (nat, address) big_map
@@ -36,15 +35,14 @@ let assert_authorisation
   (from_ : address)
   (token_id : nat)
 : unit =
-  let sender_ = (Tezos.get_sender ()) in
-  if (sender_ = from_)
-  then ()
-  else
+  let sender_ = Tezos.get_sender () in
+  if sender_ <> from_
+  then
     let authorized =
       match Big_map.find_opt (from_, sender_) operators with
         Some (a) -> a
       | None -> Set.empty in
-    if Set.mem token_id authorized then () else failwith Errors.not_operator
+    if not (Set.mem token_id authorized) then failwith Errors.not_operator
 
 let is_operator
   (operators, owner, operator, token_id : (operators * address * address * nat))
@@ -96,11 +94,11 @@ let remove_operator
 
 //module Ledger = struct
 let is_owner_of (ledger : ledger) (token_id : nat) (owner : address) : bool =
-  let current_owner = Option.unopt (Big_map.find_opt token_id ledger) in
+  let current_owner: address = Option.value_with_error "Option is None" (Big_map.find_opt token_id ledger) in
   current_owner = owner
 
 let assert_owner_of (ledger : ledger) (token_id : nat) (owner : address) : unit =
-  assert_with_error (is_owner_of ledger token_id owner) Errors.ins_balance
+  Assert.Error.assert (is_owner_of ledger token_id owner) Errors.ins_balance
 
 let transfer_token_from_user_to_user
   (ledger : ledger)
@@ -176,7 +174,7 @@ let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
      balance = balance_
     } in
   let callback_param = List.map get_balance_info requests in
-  let operation = Tezos.transaction (Main callback_param) 0mutez callback in
+  let operation = Tezos.Next.Operation.transaction (Main callback_param) 0mutez callback in
   ([operation] : operation list), s
 
 let update_operators (type a)

--- a/lib/fa2/nft/nft.impl.jsligo
+++ b/lib/fa2/nft/nft.impl.jsligo
@@ -1,7 +1,7 @@
-export #import "../common/assertions.jsligo" "Assertions"
+#import "../common/assertions.jsligo" "Assertions"
 export #import "../common/errors.mligo" "Errors"
 export #import "../common/tzip12.datatypes.jsligo" "TZIP12"
-export #import "../common/tzip16.datatypes.jsligo" "TZIP16"
+#import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 #import "./extendable_nft.impl.jsligo" "NFTExtendable"
 

--- a/lib/fa2/nft/nft.impl.mligo
+++ b/lib/fa2/nft/nft.impl.mligo
@@ -1,9 +1,9 @@
-[@public] #import "../common/assertions.jsligo" "Assertions"
+#import "../common/assertions.jsligo" "Assertions"
 [@public] #import "../common/errors.mligo" "Errors"
 [@public] #import "../common/tzip12.datatypes.jsligo" "TZIP12"
-[@public] #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-[@public] #import "../common/tzip16.datatypes.jsligo" "TZIP16"
-#import "./extendable_nft.impl.mligo" "NFTExtendable"
+#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
+#import "./extendable_nft.impl.jsligo" "NFTExtendable"
 
 type ledger = NFTExtendable.ledger
 
@@ -40,8 +40,7 @@ let lift (s : storage) : unit NFTExtendable.storage =
   }
 
 [@inline]
-let unlift (ret : operation list * unit NFTExtendable.storage) : ret =
-  let ops, s = ret in
+let unlift (ops, s : operation list * unit NFTExtendable.storage) : ret =
   ops,
   {
    ledger = s.ledger;

--- a/ligo.json
+++ b/ligo.json
@@ -1,21 +1,28 @@
 {
-  "name": "@ligo/fa",
-  "version": "1.4.2",
-  "description": "FA2 interface and types compliant with TZIP12. The library is also providing 3 Ligo contract implementations for nft, single asset & multi asset contracts",
-  "directories": {
-    "lib": "lib",
-    "test": "test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/ligolang/contract-catalogue.git"
-  },
-  "main": "lib/main.mligo",
-  "keywords": ["ligo", "ligo@^1.5.0", "tezos", "jsligo", "cameligo", "nft"],
-  "author": "ligoLANG <https://ligolang.org/>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/ligolang/contract-catalogue/issues"
-  },
-  "homepage": "https://github.com/ligolang/contract-catalogue#readme"
+    "name": "@ligo/fa",
+    "version": "1.4.3",
+    "description": "FA2 interface and types compliant with TZIP12. The library is also providing 3 Ligo contract implementations for nft, single asset & multi asset contracts",
+    "directories": {
+        "lib": "lib",
+        "test": "test"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/ligolang/contract-catalogue.git"
+    },
+    "main": "lib/main.mligo",
+    "keywords": [
+        "ligo",
+        "ligo@^1.7.0",
+        "tezos",
+        "jsligo",
+        "cameligo",
+        "nft"
+    ],
+    "author": "ligoLANG <https://ligolang.org/>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/ligolang/contract-catalogue/issues"
+    },
+    "homepage": "https://github.com/ligolang/contract-catalogue#readme"
 }

--- a/ligo.json
+++ b/ligo.json
@@ -1,6 +1,6 @@
 {
     "name": "@ligo/fa",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "description": "FA2 interface and types compliant with TZIP12. The library is also providing 3 Ligo contract implementations for nft, single asset & multi asset contracts",
     "directories": {
         "lib": "lib",

--- a/ligo.json
+++ b/ligo.json
@@ -1,6 +1,6 @@
 {
     "name": "@ligo/fa",
-    "version": "1.4.4",
+    "version": "1.4.3",
     "description": "FA2 interface and types compliant with TZIP12. The library is also providing 3 Ligo contract implementations for nft, single asset & multi asset contracts",
     "directories": {
         "lib": "lib",

--- a/test/fa2/multi_asset.test.mligo
+++ b/test/fa2/multi_asset.test.mligo
@@ -20,17 +20,17 @@ module List_helper = struct
 end
 
 let get_initial_storage (a, b, c : nat * nat * nat) =
-  let () = Test.reset_state 6n ([] : tez list) in
+  let () = Test.Next.State.reset 6n ([] : tez list) in
 
-  let owner1 = Test.nth_bootstrap_account 0 in
-  let owner2 = Test.nth_bootstrap_account 1 in
-  let owner3 = Test.nth_bootstrap_account 2 in
+  let owner1 = Test.Next.Account.address 0n in
+  let owner2 = Test.Next.Account.address 1n in
+  let owner3 = Test.Next.Account.address 2n in
 
   let owners = [owner1; owner2; owner3] in
 
-  let op1 = Test.nth_bootstrap_account 3 in
-  let op2 = Test.nth_bootstrap_account 4 in
-  let op3 = Test.nth_bootstrap_account 5 in
+  let op1 = Test.Next.Account.address 3n in
+  let op2 = Test.Next.Account.address 4n in
+  let op3 = Test.Next.Account.address 5n in
 
   let ops = [op1; op2; op3] in
 
@@ -92,18 +92,18 @@ let assert_balances
   let (owner1, token_id_1, balance1) = a in
   let (owner2, token_id_2, balance2) = b in
   let (owner3, token_id_3, balance3) = c in
-  let storage = Test.get_storage contract_address in
+  let storage = Test.Next.Typed_address.get_storage contract_address in
   let ledger = storage.ledger in
   let () = match (Big_map.find_opt (owner1, token_id_1) ledger) with
-    Some amt -> assert (amt = balance1)
+    Some amt -> Test.Next.Assert.assert (amt = balance1)
   | None -> failwith "incorret address"
   in
   let () = match (Big_map.find_opt (owner2, token_id_2) ledger) with
-    Some amt ->  assert (amt = balance2)
+    Some amt ->  Test.Next.Assert.assert (amt = balance2)
   | None -> failwith "incorret address"
   in
   let () = match (Big_map.find_opt (owner3, token_id_3) ledger) with
-    Some amt -> assert (amt = balance3)
+    Some amt -> Test.Next.Assert.assert (amt = balance3)
   | None -> failwith "incorret address"
   in
   ()
@@ -122,11 +122,11 @@ let test_atomic_transfer_success =
     ({from_=owner1; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = assert_balances orig.addr ((owner1, 2n, 8n), (owner2, 2n, 12n), (owner3, 3n, 10n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = assert_balances orig.taddr ((owner1, 2n, 8n), (owner2, 2n, 12n), (owner3, 3n, 10n)) in
   ()
 
 (* 2. transfer failure token undefined *)
@@ -141,13 +141,13 @@ let test_transfer_token_undefined =
     ({from_=owner2; txs=([{to_=owner3;amount=2n;token_id=0n};{to_=owner1;amount=3n;token_id=2n}] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.undefined_token))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.undefined_token))
   | Fail _ -> failwith "invalid test failure"
 
 (* 3. transfer failure incorrect operator *)
@@ -160,13 +160,13 @@ let test_atomic_transfer_failure_not_operator =
     ({from_=owner1; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op3 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* 4. transfer failure insuffient balance *)
@@ -179,13 +179,13 @@ let test_atomic_transfer_failure_not_suffient_balance =
     ({from_=owner1; txs=([{to_=owner2;amount=12n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.ins_balance))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.ins_balance))
   | Fail _ -> failwith "invalid test failure"
 
 (* 5. transfer successful 0 amount & self transfer *)
@@ -200,11 +200,11 @@ let test_atomic_transfer_success_zero_amount_and_self_transfer =
     ({from_=owner2; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = assert_balances orig.addr ((owner1, 1n, 10n), (owner2, 2n, 10n), (owner3, 3n, 10n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = assert_balances orig.taddr ((owner1, 1n, 10n), (owner2, 2n, 10n), (owner3, 3n, 10n)) in
   ()
 
 (* 6. transfer failure transitive operators *)
@@ -217,13 +217,13 @@ let test_transfer_failure_transitive_operators =
     ({from_=owner3; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op3 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* Balance of *)
@@ -231,28 +231,28 @@ let test_transfer_failure_transitive_operators =
 (* 7. empty balance of + callback with empty response *)
 let test_empty_transfer_and_balance_of =
   let initial_storage, _owners, _operators = get_initial_storage (10n, 10n, 10n) in
-  let orig_callback= Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback= Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([] : FA2_multi_asset.TZIP12.request list);
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([] : nat list))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([] : nat list))
 
 (* 8. balance of failure token undefined *)
 let test_balance_of_token_undefines =
   let initial_storage, owners, _operators = get_initial_storage (10n, 5n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
-  let orig_callback= Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback= Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([
@@ -263,13 +263,13 @@ let test_balance_of_token_undefines =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Balance_of balance_of_requests) 0tez in
 
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.undefined_token))
+  | Fail (Rejected (err, _))  -> Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.undefined_token))
   | Fail _ -> failwith "invalid test failure"
 
 (* 9. duplicate balance_of requests *)
@@ -279,8 +279,8 @@ let test_balance_of_requests_with_duplicates =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let _op1   = List_helper.nth_exn 0 operators in
-  let orig_callback= Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback= Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([
@@ -291,12 +291,12 @@ let test_balance_of_requests_with_duplicates =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([10n; 5n; 10n]))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([10n; 5n; 10n]))
 
 (* 10. 0 balance if does not hold any tokens (not in ledger) *)
 let test_balance_of_0_balance_if_address_does_not_hold_tokens =
@@ -305,8 +305,8 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
     let owner2 = List_helper.nth_exn 1 owners in
     let _owner3= List_helper.nth_exn 2 owners in
     let op1    = List_helper.nth_exn 0 operators in
-    let orig_callback= Test.originate (contract_of Callback) ([] : nat list) 0tez in
-    let callback_contract = Test.to_contract orig_callback.addr in
+    let orig_callback= Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+    let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
     let balance_of_requests = ({
       requests = ([
@@ -317,12 +317,12 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
       callback = callback_contract;
     } : FA2_multi_asset.TZIP12.balance_of) in
 
-    let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+    let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-    let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+    let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-    let callback_storage = Test.get_storage orig_callback.addr in
-    assert (callback_storage = ([10n; 5n; 0n]))
+    let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+    Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([10n; 5n; 0n]))
 
 
 (* Update operators *)
@@ -334,11 +334,11 @@ let test_update_operator_remove_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Remove_operator ({
         owner    = owner1;
@@ -347,15 +347,15 @@ let test_update_operator_remove_operator_and_transfer =
       } : FA2_multi_asset.TZIP12.operator) : FA2_multi_asset.TZIP12.unit_update)
     ] : FA2_multi_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op1 in
+  let () = Test.Next.State.set_source op1 in
   let transfer_requests = ([
     ({from_=owner1; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* 12. Add operator & do transfer - success *)
@@ -365,11 +365,11 @@ let test_update_operator_add_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner1;
@@ -378,10 +378,10 @@ let test_update_operator_add_operator_and_transfer =
       } : FA2_multi_asset.TZIP12.operator) : FA2_multi_asset.TZIP12.unit_update);
     ] : FA2_multi_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op3 in
+  let () = Test.Next.State.set_source op3 in
   let transfer_requests = ([
     ({from_=owner1; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
   ()

--- a/test/fa2/multi_asset_jsligo.test.mligo
+++ b/test/fa2/multi_asset_jsligo.test.mligo
@@ -21,17 +21,17 @@ module List_helper = struct
 end
 
 let get_initial_storage (a, b, c : nat * nat * nat) =
-  let () = Test.reset_state 6n ([] : tez list) in
+  let () = Test.Next.State.reset 6n ([] : tez list) in
 
-  let owner1 = Test.nth_bootstrap_account 0 in
-  let owner2 = Test.nth_bootstrap_account 1 in
-  let owner3 = Test.nth_bootstrap_account 2 in
+  let owner1 = Test.Next.Account.address 0n in
+  let owner2 = Test.Next.Account.address 1n in
+  let owner3 = Test.Next.Account.address 2n in
 
   let owners = [owner1; owner2; owner3] in
 
-  let op1 = Test.nth_bootstrap_account 3 in
-  let op2 = Test.nth_bootstrap_account 4 in
-  let op3 = Test.nth_bootstrap_account 5 in
+  let op1 = Test.Next.Account.address 3n in
+  let op2 = Test.Next.Account.address 4n in
+  let op3 = Test.Next.Account.address 5n in
 
   let ops = [op1; op2; op3] in
 
@@ -92,18 +92,18 @@ let assert_balances
   let (owner1, token_id_1, balance1) = a in
   let (owner2, token_id_2, balance2) = b in
   let (owner3, token_id_3, balance3) = c in
-  let storage = Test.get_storage contract_address in
+  let storage = Test.Next.Typed_address.get_storage contract_address in
   let ledger = storage.ledger in
   let () = match (Big_map.find_opt (owner1, token_id_1) ledger) with
-    Some amt -> assert (amt = balance1)
+    Some amt -> Test.Next.Assert.assert (amt = balance1)
   | None -> failwith "incorret address"
   in
   let () = match (Big_map.find_opt (owner2, token_id_2) ledger) with
-    Some amt ->  assert (amt = balance2)
+    Some amt ->  Test.Next.Assert.assert (amt = balance2)
   | None -> failwith "incorret address"
   in
   let () = match (Big_map.find_opt (owner3, token_id_3) ledger) with
-    Some amt -> assert (amt = balance3)
+    Some amt -> Test.Next.Assert.assert (amt = balance3)
   | None -> failwith "incorret address"
   in
   ()
@@ -122,11 +122,11 @@ let test_atomic_transfer_success =
     ({from_=owner1; txs=([{to_=owner2;amount=2n;token_id=2n}] : FA2_multi_asset.TZIP12.atomic_trans list)} );
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = assert_balances orig.addr ((owner1, 2n, 8n), (owner2, 2n, 12n), (owner3, 3n, 10n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = assert_balances orig.taddr ((owner1, 2n, 8n), (owner2, 2n, 12n), (owner3, 3n, 10n)) in
   ()
 
 (* 2. transfer failure token undefined *)
@@ -141,13 +141,13 @@ let test_transfer_token_undefined =
     ({from_=owner2; txs=([{to_=owner3;amount=2n;token_id=0n};{to_=owner1;amount=3n;token_id=2n}] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.undefined_token))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.undefined_token))
   | Fail _ -> failwith "invalid test failure"
 
 (* 3. transfer failure incorrect operator *)
@@ -160,13 +160,13 @@ let test_atomic_transfer_failure_not_operator =
     ({from_=owner1; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op3 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* 4. transfer failure insuffient balance *)
@@ -179,13 +179,13 @@ let test_atomic_transfer_failure_not_suffient_balance =
     ({from_=owner1; txs=([{to_=owner2;amount=12n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.ins_balance))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.ins_balance))
   | Fail _ -> failwith "invalid test failure"
 
 (* 5. transfer successful 0 amount & self transfer *)
@@ -200,11 +200,11 @@ let test_atomic_transfer_success_zero_amount_and_self_transfer =
     ({from_=owner2; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = assert_balances orig.addr ((owner1, 1n, 10n), (owner2, 2n, 10n), (owner3, 3n, 10n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = assert_balances orig.taddr ((owner1, 1n, 10n), (owner2, 2n, 10n), (owner3, 3n, 10n)) in
   ()
 
 (* 6. transfer failure transitive operators *)
@@ -217,13 +217,13 @@ let test_transfer_failure_transitive_operators =
     ({from_=owner3; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op3 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* Balance of *)
@@ -231,28 +231,28 @@ let test_transfer_failure_transitive_operators =
 (* 7. empty balance of + callback with empty response *)
 let test_empty_transfer_and_balance_of =
   let initial_storage, _owners, _operators = get_initial_storage (10n, 10n, 10n) in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([] : FA2_multi_asset.TZIP12.request list);
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([] : nat list))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([] : nat list))
 
 (* 8. balance of failure token undefined *)
 let test_balance_of_token_undefines =
   let initial_storage, owners, _operators = get_initial_storage (10n, 5n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([
@@ -263,13 +263,13 @@ let test_balance_of_token_undefines =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Balance_of balance_of_requests) 0tez in
 
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.undefined_token))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.undefined_token))
   | Fail _ -> failwith "invalid test failure"
 
 (* 9. duplicate balance_of requests *)
@@ -279,8 +279,8 @@ let test_balance_of_requests_with_duplicates =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let _op1   = List_helper.nth_exn 0 operators in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([
@@ -291,12 +291,12 @@ let test_balance_of_requests_with_duplicates =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([10n; 5n; 10n]))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([10n; 5n; 10n]))
 
 (* 10. 0 balance if does not hold any tokens (not in ledger) *)
 let test_balance_of_0_balance_if_address_does_not_hold_tokens =
@@ -305,8 +305,8 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
     let owner2 = List_helper.nth_exn 1 owners in
     let _owner3= List_helper.nth_exn 2 owners in
     let op1    = List_helper.nth_exn 0 operators in
-    let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-    let callback_contract = Test.to_contract orig_callback.addr in
+    let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+    let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
     let balance_of_requests = ({
       requests = ([
@@ -317,12 +317,12 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
       callback = callback_contract;
     } : FA2_multi_asset.TZIP12.balance_of) in
 
-    let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+    let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
-    let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+    let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-    let callback_storage = Test.get_storage orig_callback.addr in
-    assert (callback_storage = ([10n; 5n; 0n]))
+    let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+    Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([10n; 5n; 0n]))
 
 
 (* Update operators *)
@@ -334,11 +334,11 @@ let test_update_operator_remove_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Remove_operator ({
         owner    = owner1;
@@ -347,15 +347,15 @@ let test_update_operator_remove_operator_and_transfer =
       } : FA2_multi_asset.TZIP12.operator) : FA2_multi_asset.TZIP12.unit_update)
     ] : FA2_multi_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op1 in
+  let () = Test.Next.State.set_source op1 in
   let transfer_requests = ([
     ({from_=owner1; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_multi_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_multi_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* 12. Add operator & do transfer - success *)
@@ -365,11 +365,11 @@ let test_update_operator_add_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_multi_asset) initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner1;
@@ -378,10 +378,10 @@ let test_update_operator_add_operator_and_transfer =
       } : FA2_multi_asset.TZIP12.operator) : FA2_multi_asset.TZIP12.unit_update);
     ] : FA2_multi_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op3 in
+  let () = Test.Next.State.set_source op3 in
   let transfer_requests = ([
     ({from_=owner1; txs=([{to_=owner2;amount=2n;token_id=2n};] : FA2_multi_asset.TZIP12.atomic_trans list)});
   ] : FA2_multi_asset.TZIP12.transfer)
   in
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
   ()

--- a/test/fa2/nft/e2e_mutation.test.mligo
+++ b/test/fa2/nft/e2e_mutation.test.mligo
@@ -27,13 +27,13 @@ let originate_and_test_e2e contract =
   ()
 
 let test_mutation =
-  match Test.mutation_test_all (contract_of  FA2_NFT.NFT) originate_and_test_e2e
+  match Test.Next.Mutation.All.func (contract_of  FA2_NFT) originate_and_test_e2e
   with
     [] -> ()
   | ms ->
       let () =
         List.iter
-          (fun ((_, mutation) : unit * mutation) -> let () = Test.log mutation in
+          (fun ((_, mutation) : unit * mutation) -> let () = Test.Next.IO.log mutation in
              ())
           ms in
-      Test.failwith "Some mutation also passes the tests! ^^"
+      Test.Next.Assert.failwith "Some mutation also passes the tests! ^^"

--- a/test/fa2/nft/nft.test.mligo
+++ b/test/fa2/nft/nft.test.mligo
@@ -22,11 +22,11 @@ let _test_atomic_transfer_operator_success (contract: fa2_nft) =
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate contract initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = TestHelpers.assert_balances orig.taddr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 
 let test_atomic_transfer_operator_success = _test_atomic_transfer_operator_success (contract_of FA2_NFT)
@@ -42,11 +42,11 @@ let _test_atomic_transfer_owner_success (contract: fa2_nft) =
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source owner1 in
-  let orig = Test.originate contract  initial_storage 0tez in
+  let () = Test.Next.State.set_source owner1 in
+  let orig = Test.Next.Originate.contract contract  initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = TestHelpers.assert_balances orig.taddr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 
 let test_atomic_transfer_owner_success = _test_atomic_transfer_owner_success (contract_of FA2_NFT)
@@ -62,10 +62,10 @@ let _test_transfer_token_undefined (contract: fa2_nft) =
     ({from_=owner1; txs=([({to_=owner2;token_id=15n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate contract  initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract contract  initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
 
 let test_transfer_token_undefined = _test_transfer_token_undefined (contract_of FA2_NFT)
@@ -81,10 +81,10 @@ let _test_atomic_transfer_failure_not_operator (contract: fa2_nft) =
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op2 in
-  let orig = Test.originate contract initial_storage 0tez in
+  let () = Test.Next.State.set_source op2 in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_atomic_transfer_failure_not_operator
 
@@ -102,10 +102,10 @@ let _test_atomic_transfer_success_zero_amount_and_self_transfer (contract: fa2_n
   ] : FA2_NFT.TZIP12.transfer)
   in
 
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = TestHelpers.assert_balances orig.addr ((owner1, 1n), (owner2, 2n), (owner3, 3n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = TestHelpers.assert_balances orig.taddr ((owner1, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 let test_atomic_transfer_success_zero_amount_and_self_transfer =
 
@@ -122,10 +122,10 @@ let _test_transfer_failure_transitive_operators (contract: fa2_nft) =
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op3 in
-  let orig = Test.originate contract initial_storage 0tez in
+  let () = Test.Next.State.set_source op3 in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_transfer_failure_transitive_operators =
 
@@ -137,20 +137,20 @@ let test_transfer_failure_transitive_operators =
 (* 6. empty balance of + callback with empty response *)
 let _test_empty_transfer_and_balance_of (contract: fa2_nft) =
   let initial_storage, _owners, _operators = TestHelpers.get_initial_storage () in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([] : FA2_NFT.TZIP12.request list);
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
 
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  Test.assert (callback_storage = ([] : nat list))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([] : nat list))
 
 let test_empty_transfer_and_balance_of = _test_empty_transfer_and_balance_of (contract_of FA2_NFT)
 
@@ -161,8 +161,8 @@ let _test_balance_of_token_undefines (contract: fa2_nft) =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let _op1   = List_helper.nth_exn 0 operators in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([
@@ -173,9 +173,9 @@ let _test_balance_of_token_undefines (contract: fa2_nft) =
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
 
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Balance_of balance_of_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
 
 let test_balance_of_token_undefines = _test_balance_of_token_undefines (contract_of FA2_NFT)
@@ -186,8 +186,8 @@ let _test_balance_of_requests_with_duplicates (contract: fa2_nft) =
   let initial_storage, owners, _ = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([
@@ -199,12 +199,12 @@ let _test_balance_of_requests_with_duplicates (contract: fa2_nft) =
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
 
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  Test.assert (callback_storage = ([1n; 1n; 1n; 0n]))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([1n; 1n; 1n; 0n]))
 let test_balance_of_requests_with_duplicates
 
   = _test_balance_of_requests_with_duplicates (contract_of FA2_NFT)
@@ -216,8 +216,8 @@ let _test_balance_of_0_balance_if_address_does_not_hold_tokens (contract: fa2_nf
     let owner1 = List_helper.nth_exn 0 owners in
     let owner2 = List_helper.nth_exn 1 owners in
     let op1    = List_helper.nth_exn 0 operators in
-    let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-    let callback_contract = Test.to_contract orig_callback.addr in
+    let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+    let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
     let balance_of_requests = ({
       requests = ([
@@ -228,12 +228,12 @@ let _test_balance_of_0_balance_if_address_does_not_hold_tokens (contract: fa2_nf
       callback = callback_contract;
     } : FA2_NFT.TZIP12.balance_of) in
 
-    let orig = Test.originate contract initial_storage 0tez in
+    let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
-    let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+    let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-    let callback_storage = Test.get_storage orig_callback.addr in
-    Test.assert (callback_storage = ([1n; 1n; 0n]))
+    let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+    Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([1n; 1n; 0n]))
 let test_balance_of_0_balance_if_address_does_not_hold_tokens =
 
   _test_balance_of_0_balance_if_address_does_not_hold_tokens (contract_of FA2_NFT)
@@ -247,11 +247,11 @@ let _test_update_operator_remove_operator_and_transfer (contract: fa2_nft) =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Remove_operator ({
         owner    = owner1;
@@ -260,12 +260,12 @@ let _test_update_operator_remove_operator_and_transfer (contract: fa2_nft) =
       } : FA2_NFT.TZIP12.operator) : FA2_NFT.TZIP12.unit_update)
     ] : FA2_NFT.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op1 in
+  let () = Test.Next.State.set_source op1 in
   let transfer_requests = ([
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_update_operator_remove_operator_and_transfer =
 
@@ -277,11 +277,11 @@ let _test_update_operator_remove_operator_and_transfer1 (contract: fa2_nft) =
   let initial_storage, owners, operators = TestHelpers.get_initial_storage () in
   let owner4 = List_helper.nth_exn 3 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
 
-  let () = Test.set_source owner4 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner4 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Remove_operator ({
         owner    = owner4;
@@ -290,10 +290,10 @@ let _test_update_operator_remove_operator_and_transfer1 (contract: fa2_nft) =
       } : FA2_NFT.TZIP12.operator) : FA2_NFT.TZIP12.unit_update)
     ] : FA2_NFT.TZIP12.update_operators)) 0tez in
 
-  let storage = Test.get_storage orig.addr in
+  let storage = Test.Next.Typed_address.get_storage orig.taddr in
   let operator_tokens = Big_map.find_opt (owner4,op1) storage.operators in
-  let operator_tokens = Option.unopt operator_tokens in
-  Test.assert (operator_tokens = Set.literal [5n])
+  let operator_tokens = Option.value_with_error "Option is None" operator_tokens in
+  Test.Next.Assert.assert (Test.Next.Compare.eq operator_tokens (Set.literal [5n]))
 let test_update_operator_remove_operator_and_transfer1 =
 
   _test_update_operator_remove_operator_and_transfer1 (contract_of FA2_NFT)
@@ -306,11 +306,11 @@ let _test_update_operator_add_operator_and_transfer (contract: fa2_nft) =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner1;
@@ -319,12 +319,12 @@ let _test_update_operator_add_operator_and_transfer (contract: fa2_nft) =
       } : FA2_NFT.TZIP12.operator) : FA2_NFT.TZIP12.unit_update);
     ] : FA2_NFT.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op3 in
+  let () = Test.Next.State.set_source op3 in
   let transfer_requests = ([
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
   ()
 let test_update_operator_add_operator_and_transfer =
 
@@ -337,11 +337,11 @@ let _test_update_operator_add_operator_and_transfer1 (contract: fa2_nft) =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner4 = List_helper.nth_exn 3 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
 
-  let () = Test.set_source owner4 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner4 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner4;
@@ -350,12 +350,12 @@ let _test_update_operator_add_operator_and_transfer1 (contract: fa2_nft) =
       } : FA2_NFT.TZIP12.operator) : FA2_NFT.TZIP12.unit_update);
     ] : FA2_NFT.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op3 in
+  let () = Test.Next.State.set_source op3 in
   let transfer_requests = ([
     ({from_=owner4; txs=([({to_=owner2;token_id=4n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
   ()
 let test_update_operator_add_operator_and_transfer1 =
 
@@ -367,11 +367,11 @@ let _test_only_sender_manage_operators (contract: fa2_nft) =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate contract initial_storage 0tez in
+  let orig = Test.Next.Originate.contract contract initial_storage 0tez in
 
 
-  let () = Test.set_source owner2 in
-  let result = Test.transfer orig.addr
+  let () = Test.Next.State.set_source owner2 in
+  let result = Test.Next.Typed_address.transfer orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner1;

--- a/test/fa2/nft/nft_jsligo.test.mligo
+++ b/test/fa2/nft/nft_jsligo.test.mligo
@@ -1,7 +1,7 @@
 #import "../../../lib/fa2/nft/nft.impl.jsligo" "FA2_NFT"
 #import "../balance_of_callback_contract.mligo" "Callback"
 #import "../../helpers/list.mligo" "List_helper"
-#import "../../helpers/nft_helpers.mligo" "TestHelpers"
+#import "../../helpers/nft_helpers.jsligo" "TestHelpers"
 (* Tests for FA2 multi asset contract *)
 type return = operation list * FA2_NFT.storage
 (* Transfer *)
@@ -16,11 +16,11 @@ let _test_atomic_transfer_operator_success () =
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
-  let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
+  let _ = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
+  let () = TestHelpers.assert_balances orig.taddr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 let test_atomic_transfer_operator_success = _test_atomic_transfer_operator_success ()
 (* 1.1. transfer successful owner *)
@@ -33,11 +33,11 @@ let _test_atomic_transfer_owner_success () =
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source owner1 in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let () = Test.Next.State.set_source owner1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
-  let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
+  let _ = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
+  let () = TestHelpers.assert_balances orig.taddr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 let test_atomic_transfer_owner_success = _test_atomic_transfer_owner_success ()
 (* 2. transfer failure token undefined *)
@@ -50,10 +50,10 @@ let _test_transfer_token_undefined () =
     ({from_=owner1; txs=([({to_=owner2;token_id=15n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
 let test_transfer_token_undefined = _test_transfer_token_undefined ()
 (* 3. transfer failure incorrect operator *)
@@ -66,10 +66,10 @@ let _test_atomic_transfer_failure_not_operator () =
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op2 in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let () = Test.Next.State.set_source op2 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_atomic_transfer_failure_not_operator
   = _test_atomic_transfer_failure_not_operator ()
@@ -84,11 +84,11 @@ let _test_atomic_transfer_success_zero_amount_and_self_transfer () =
     ({from_=owner2; txs=([({to_=owner2;token_id=2n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
-  let () = TestHelpers.assert_balances orig.addr ((owner1, 1n), (owner2, 2n), (owner3, 3n)) in
+  let _ = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
+  let () = TestHelpers.assert_balances orig.taddr ((owner1, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 let test_atomic_transfer_success_zero_amount_and_self_transfer =
   _test_atomic_transfer_success_zero_amount_and_self_transfer ()
@@ -102,10 +102,10 @@ let _test_transfer_failure_transitive_operators () =
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let () = Test.Next.State.set_source op3 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_transfer_failure_transitive_operators =
   _test_transfer_failure_transitive_operators ()
@@ -113,17 +113,17 @@ let test_transfer_failure_transitive_operators =
 (* 6. empty balance of + callback with empty response *)
 let _test_empty_transfer_and_balance_of () =
   let initial_storage, _owners, _operators = TestHelpers.get_initial_storage () in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
   let balance_of_requests = ({
     requests = ([] : FA2_NFT.TZIP12.request list);
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let _ = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
-  let callback_storage = Test.get_storage orig_callback.addr in
-  Test.assert (List.size(callback_storage) = 0n)
+  let _ = Test.Next.Typed_address.transfer orig.taddr (Balance_of balance_of_requests) 0tez in
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (List.size(callback_storage) = 0n)
 let test_empty_transfer_and_balance_of = _test_empty_transfer_and_balance_of ()
 (* 7. balance of failure token undefined *)
 let _test_balance_of_token_undefines () =
@@ -131,8 +131,8 @@ let _test_balance_of_token_undefines () =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let _op1   = List_helper.nth_exn 0 operators in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
   let balance_of_requests = ({
     requests = ([
       {owner=owner1;token_id=0n};
@@ -141,9 +141,9 @@ let _test_balance_of_token_undefines () =
     ] : FA2_NFT.TZIP12.request list);
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Balance_of balance_of_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
 let test_balance_of_token_undefines = _test_balance_of_token_undefines ()
 (* 8. duplicate balance_of requests *)
@@ -151,8 +151,8 @@ let _test_balance_of_requests_with_duplicates () =
   let initial_storage, owners, _ = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
   let balance_of_requests = ({
     requests = ([
       {owner=owner1;token_id=1n};
@@ -162,11 +162,11 @@ let _test_balance_of_requests_with_duplicates () =
     ] : FA2_NFT.TZIP12.request list);
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let _ = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
-  let callback_storage = Test.get_storage orig_callback.addr in
-  Test.assert (callback_storage = ([1n; 1n; 1n; 0n]))
+  let _ = Test.Next.Typed_address.transfer orig.taddr (Balance_of balance_of_requests) 0tez in
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage [1n; 1n; 1n; 0n])
 let test_balance_of_requests_with_duplicates
   = _test_balance_of_requests_with_duplicates ()
 (* 9. 0 balance if does not hold any tokens (not in ledger) *)
@@ -175,8 +175,8 @@ let _test_balance_of_0_balance_if_address_does_not_hold_tokens () =
     let owner1 = List_helper.nth_exn 0 owners in
     let owner2 = List_helper.nth_exn 1 owners in
     let op1    = List_helper.nth_exn 0 operators in
-    let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-    let callback_contract = Test.to_contract orig_callback.addr in
+    let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+    let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
     let balance_of_requests = ({
       requests = ([
         {owner=owner1;token_id=1n};
@@ -185,11 +185,11 @@ let _test_balance_of_0_balance_if_address_does_not_hold_tokens () =
       ] : FA2_NFT.TZIP12.request list);
       callback = callback_contract;
     } : FA2_NFT.TZIP12.balance_of) in
-    let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+    let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-    let _ = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
-    let callback_storage = Test.get_storage orig_callback.addr in
-    Test.assert (callback_storage = ([1n; 1n; 0n]))
+    let _ = Test.Next.Typed_address.transfer orig.taddr (Balance_of balance_of_requests) 0tez in
+    let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+    Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage [1n; 1n; 0n])
 let test_balance_of_0_balance_if_address_does_not_hold_tokens =
   _test_balance_of_0_balance_if_address_does_not_hold_tokens ()
 (* Update operators *)
@@ -199,10 +199,10 @@ let _test_update_operator_remove_operator_and_transfer () =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer orig.taddr
     (Update_operators ([
       (Remove_operator ({
         owner    = owner1;
@@ -210,12 +210,12 @@ let _test_update_operator_remove_operator_and_transfer () =
         token_id = 1n;
       } : FA2_NFT.TZIP12.operator) : FA2_NFT.TZIP12.unit_update)
     ] : FA2_NFT.TZIP12.update_operators)) 0tez in
-  let () = Test.set_source op1 in
+  let () = Test.Next.State.set_source op1 in
   let transfer_requests = ([
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_update_operator_remove_operator_and_transfer =
   _test_update_operator_remove_operator_and_transfer ()
@@ -224,10 +224,10 @@ let _test_update_operator_remove_operator_and_transfer1 () =
   let initial_storage, owners, operators = TestHelpers.get_initial_storage () in
   let owner4 = List_helper.nth_exn 3 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let () = Test.set_source owner4 in
-  let _ = Test.transfer orig.addr
+  let () = Test.Next.State.set_source owner4 in
+  let _ = Test.Next.Typed_address.transfer orig.taddr
     (Update_operators ([
       (Remove_operator ({
         owner    = owner4;
@@ -235,10 +235,10 @@ let _test_update_operator_remove_operator_and_transfer1 () =
         token_id = 4n;
       } : FA2_NFT.TZIP12.operator) : FA2_NFT.TZIP12.unit_update)
     ] : FA2_NFT.TZIP12.update_operators)) 0tez in
-  let storage = Test.get_storage orig.addr in
+  let storage = Test.Next.Typed_address.get_storage orig.taddr in
   let operator_tokens = Big_map.find_opt (owner4,op1) storage.operators in
-  let operator_tokens = Option.unopt operator_tokens in
-  Test.assert (operator_tokens = Set.literal [5n])
+  let operator_tokens = Option.value_with_error "option is None" operator_tokens in
+  Test.Next.Assert.assert (Test.Next.Compare.eq operator_tokens (Set.literal [5n]))
 let test_update_operator_remove_operator_and_transfer1 =
   _test_update_operator_remove_operator_and_transfer1 ()
 (* 11. Add operator & do transfer - success *)
@@ -247,10 +247,10 @@ let _test_update_operator_add_operator_and_transfer () =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner1;
@@ -258,12 +258,12 @@ let _test_update_operator_add_operator_and_transfer () =
         token_id = 1n;
       } : FA2_NFT.TZIP12.operator) : FA2_NFT.TZIP12.unit_update);
     ] : FA2_NFT.TZIP12.update_operators)) 0tez in
-  let () = Test.set_source op3 in
+  let () = Test.Next.State.set_source op3 in
   let transfer_requests = ([
     ({from_=owner1; txs=([({to_=owner2;token_id=1n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   ()
 let test_update_operator_add_operator_and_transfer =
   _test_update_operator_add_operator_and_transfer ()
@@ -273,10 +273,10 @@ let _test_update_operator_add_operator_and_transfer1 () =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner4 = List_helper.nth_exn 3 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let () = Test.set_source owner4 in
-  let _ = Test.transfer orig.addr
+  let () = Test.Next.State.set_source owner4 in
+  let _ = Test.Next.Typed_address.transfer orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner4;
@@ -284,12 +284,12 @@ let _test_update_operator_add_operator_and_transfer1 () =
         token_id = 4n;
       } : FA2_NFT.TZIP12.operator) : FA2_NFT.TZIP12.unit_update);
     ] : FA2_NFT.TZIP12.update_operators)) 0tez in
-  let () = Test.set_source op3 in
+  let () = Test.Next.State.set_source op3 in
   let transfer_requests = ([
     ({from_=owner4; txs=([({to_=owner2;token_id=4n;amount=1n} : FA2_NFT.TZIP12.atomic_trans);])});
   ] : FA2_NFT.TZIP12.transfer)
   in
-  let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   ()
 let test_update_operator_add_operator_and_transfer1 =
   _test_update_operator_add_operator_and_transfer1 ()
@@ -298,10 +298,10 @@ let _test_only_sender_manage_operators () =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
-  let () = Test.set_source owner2 in
-  let result = Test.transfer orig.addr
+  let () = Test.Next.State.set_source owner2 in
+  let result = Test.Next.Typed_address.transfer orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner1;

--- a/test/fa2/nft/views.test.mligo
+++ b/test/fa2/nft/views.test.mligo
@@ -12,69 +12,69 @@ let test_get_balance_view =
   let initial_storage, owners, _ = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
 
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
 
   let initial_storage : ViewsTestContract.storage = {
-    main_contract = Test.to_address orig.addr;
+    main_contract = Test.Next.Typed_address.to_address orig.taddr;
     get_balance   = (None : nat option);
     total_supply  = (None : nat option);
     is_operator   = (None : bool option);
     all_tokens    = (None : nat set option);
   } in
 
-  let orig_v = Test.originate (contract_of ViewsTestContract) initial_storage 0tez in
+  let orig_v = Test.Next.Originate.contract (contract_of ViewsTestContract) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig_v.addr
+  let _ = Test.Next.Typed_address.transfer_exn orig_v.taddr
     (Get_balance (owner1,1n) : ViewsTestContract parameter_of) 0tez
   in
-  let storage = Test.get_storage orig_v.addr in
+  let storage = Test.Next.Typed_address.get_storage orig_v.taddr in
   let get_balance = storage.get_balance in
-  assert (get_balance = Some 1n)
+  Test.Next.Assert.assert (get_balance = Some 1n)
 
 (* Test total_supply view *)
 let test_total_supply_view =
   let initial_storage, _, _ = TestHelpers.get_initial_storage () in
 
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
 
   let initial_storage : ViewsTestContract.storage = {
-    main_contract = Test.to_address orig.addr;
+    main_contract = Test.Next.Typed_address.to_address orig.taddr;
     get_balance   = (None : nat option);
     total_supply  = (None : nat option);
     is_operator   = (None : bool option);
     all_tokens    = (None : nat set option);
   } in
 
-  let orig_v = Test.originate (contract_of ViewsTestContract) initial_storage 0tez in
+  let orig_v = Test.Next.Originate.contract (contract_of ViewsTestContract) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig_v.addr
+  let _ = Test.Next.Typed_address.transfer_exn orig_v.taddr
     (Total_supply 2n : ViewsTestContract parameter_of) 0tez
   in
-  let storage = Test.get_storage orig_v.addr in
+  let storage = Test.Next.Typed_address.get_storage orig_v.taddr in
   let total_supply = storage.total_supply in
-  assert (total_supply = Some 1n)
+  Test.Next.Assert.assert (total_supply = Some 1n)
 
 
 (* Test total_supply view - undefined token *)
 let test_total_supply_undefined_token_view =
   let initial_storage, _, _ = TestHelpers.get_initial_storage () in
 
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
 
   let initial_storage : ViewsTestContract.storage = {
-    main_contract = Test.to_address orig.addr;
+    main_contract = Test.Next.Typed_address.to_address orig.taddr;
     get_balance   = (None : nat option);
     total_supply  = (None : nat option);
     is_operator   = (None : bool option);
     all_tokens    = (None : nat set option);
   } in
 
-  let orig_v = Test.originate (contract_of ViewsTestContract) initial_storage 0tez in
+  let orig_v = Test.Next.Originate.contract (contract_of ViewsTestContract) initial_storage 0tez in
 
-  let result = Test.transfer orig_v.addr
+  let result = Test.Next.Typed_address.transfer orig_v.taddr
     (Total_supply 15n : ViewsTestContract parameter_of) 0tez
   in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
@@ -85,28 +85,28 @@ let test_is_operator_view =
   let owner1 = List_helper.nth_exn 0 owners in
   let op1    = List_helper.nth_exn 0 operators in
 
-  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_NFT) initial_storage 0tez in
 
 
   let initial_storage : ViewsTestContract.storage = {
-    main_contract = Test.to_address orig.addr;
+    main_contract = Test.Next.Typed_address.to_address orig.taddr;
     get_balance   = (None : nat option);
     total_supply  = (None : nat option);
     is_operator   = (None : bool option);
     all_tokens    = (None : nat set option);
   } in
 
-  let orig_v = Test.originate (contract_of ViewsTestContract) initial_storage 0tez in
+  let orig_v = Test.Next.Originate.contract (contract_of ViewsTestContract) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig_v.addr
+  let _ = Test.Next.Typed_address.transfer_exn orig_v.taddr
     (Is_operator {
       owner    = owner1;
       operator = op1;
       token_id = 1n;
     } : ViewsTestContract parameter_of) 0tez
   in
-  let storage = Test.get_storage orig_v.addr in
+  let storage = Test.Next.Typed_address.get_storage orig_v.taddr in
   let is_operator = storage.is_operator in
-  assert (is_operator = Some true)
+  Assert.assert (is_operator = Some true)
 
 

--- a/test/fa2/single_asset.test.mligo
+++ b/test/fa2/single_asset.test.mligo
@@ -20,17 +20,17 @@ module List_helper = struct
 end
 
 let get_initial_storage (a, b, c : nat * nat * nat) =
-  let () = Test.reset_state 6n ([] : tez list) in
+  let () = Test.Next.State.reset 6n ([] : tez list) in
 
-  let owner1 = Test.nth_bootstrap_account 0 in
-  let owner2 = Test.nth_bootstrap_account 1 in
-  let owner3 = Test.nth_bootstrap_account 2 in
+  let owner1 = Test.Next.Account.address 0n in
+  let owner2 = Test.Next.Account.address 1n in
+  let owner3 = Test.Next.Account.address 2n in
 
   let owners = [owner1; owner2; owner3] in
 
-  let op1 = Test.nth_bootstrap_account 3 in
-  let op2 = Test.nth_bootstrap_account 4 in
-  let op3 = Test.nth_bootstrap_account 5 in
+  let op1 = Test.Next.Account.address 3n in
+  let op2 = Test.Next.Account.address 4n in
+  let op3 = Test.Next.Account.address 5n in
 
   let ops = [op1; op2; op3] in
 
@@ -93,18 +93,18 @@ let assert_balances
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in
   let (owner3, balance3) = c in
-  let storage = Test.get_storage contract_address in
+  let storage = Test.Next.Typed_address.get_storage contract_address in
   let ledger = storage.ledger in
   let () = match (Big_map.find_opt owner1 ledger) with
-    Some amt -> assert (amt = balance1)
+    Some amt -> Test.Next.Assert.assert (amt = balance1)
   | None -> failwith "incorret address"
   in
   let () = match (Big_map.find_opt owner2 ledger) with
-    Some amt ->  assert (amt = balance2)
+    Some amt ->  Test.Next.Assert.assert (amt = balance2)
   | None -> failwith "incorret address"
   in
   let () = match (Big_map.find_opt owner3 ledger) with
-    Some amt -> assert (amt = balance3)
+    Some amt -> Test.Next.Assert.assert (amt = balance3)
   | None -> failwith "incorret address"
   in
   ()
@@ -123,11 +123,11 @@ let test_atomic_transfer_success =
     ({from_=owner2; txs=([{to_=owner3;token_id=0n;amount=2n};{to_=owner1;token_id=0n;amount=3n}] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = assert_balances orig.addr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = assert_balances orig.taddr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
   ()
 
 (* 2. transfer failure incorrect operator *)
@@ -142,13 +142,13 @@ let test_atomic_transfer_failure_not_operator =
     ({from_=owner2; txs=([{to_=owner3;token_id=0n;amount=2n};{to_=owner1;token_id=0n;amount=3n}] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op3 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_single_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_single_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* 3. transfer failure insuffient balance *)
@@ -163,13 +163,13 @@ let test_atomic_transfer_failure_not_suffient_balance =
     ({from_=owner2; txs=([{to_=owner3;token_id=0n;amount=2n};{to_=owner1;token_id=0n;amount=3n}] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_single_asset.Errors.ins_balance))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_single_asset.Errors.ins_balance))
   | Fail _ -> failwith "invalid test failure"
 
 (* 4. transfer successful 0 amount & self transfer *)
@@ -184,11 +184,11 @@ let test_atomic_transfer_success_zero_amount_and_self_transfer =
     ({from_=owner2; txs=([{to_=owner2;token_id=0n;amount=2n};] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = assert_balances orig.addr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = assert_balances orig.taddr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
   ()
 
 (* 5. transfer failure transitive operators *)
@@ -202,13 +202,13 @@ let test_transfer_failure_transitive_operators =
       ({from_=owner3; txs=([{to_=owner2;token_id=0n;amount=2n};] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op2 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op2 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_single_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_single_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* Balance of *)
@@ -216,19 +216,19 @@ let test_transfer_failure_transitive_operators =
 (* 6. empty balance of + callback with empty response *)
 let test_empty_transfer_and_balance_of =
   let initial_storage, _owners, _operators = get_initial_storage (10n, 10n, 10n) in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
 
   let balance_of_requests = ({
     requests = ([] : FA2_single_asset.TZIP12.request list);
-    callback = Test.to_contract orig_callback.addr;
+    callback = Test.Next.Typed_address.to_contract orig_callback.taddr;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([] : nat list))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([] : nat list))
 
 (* 7. duplicate balance_of requests *)
 let test_balance_of_requests_with_duplicates =
@@ -237,7 +237,7 @@ let test_balance_of_requests_with_duplicates =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let _op1   = List_helper.nth_exn 0 operators in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
 
 
   let balance_of_requests = ({
@@ -246,15 +246,15 @@ let test_balance_of_requests_with_duplicates =
       {owner=owner2;token_id=0n};
       {owner=owner1;token_id=0n};
     ] : FA2_single_asset.TZIP12.request list);
-    callback = Test.to_contract orig_callback.addr;
+    callback = Test.Next.Typed_address.to_contract orig_callback.taddr;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([10n; 5n; 10n]))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([10n; 5n; 10n]))
 
 (* 8. 0 balance if does not hold any tokens (not in ledger) *)
 let test_balance_of_0_balance_if_address_does_not_hold_tokens =
@@ -263,7 +263,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
 
 
   let balance_of_requests = ({
@@ -272,15 +272,15 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
       {owner=owner2;token_id=0n};
       {owner=op1;token_id=0n};
     ] : FA2_single_asset.TZIP12.request list);
-    callback = Test.to_contract orig_callback.addr;
+    callback = Test.Next.Typed_address.to_contract orig_callback.taddr;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([10n; 5n; 0n]))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage  ([10n; 5n; 0n]))
 
 (* Update operators *)
 
@@ -291,11 +291,11 @@ let test_update_operator_remove_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner3 = List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Remove_operator ({
         owner    = owner1;
@@ -304,16 +304,16 @@ let test_update_operator_remove_operator_and_transfer =
       } : FA2_single_asset.TZIP12.operator) : FA2_single_asset.TZIP12.unit_update)
     ] : FA2_single_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op1 in
+  let () = Test.Next.State.set_source op1 in
   let transfer_requests = ([
     ({from_=owner1; txs=([{to_=owner2;token_id=0n;amount=0n};{to_=owner3;token_id=0n;amount=0n}] : FA2_single_asset.TZIP12.atomic_trans list)});
     ({from_=owner2; txs=([{to_=owner2;token_id=0n;amount=2n};] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_single_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_single_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* 10. Add operator & do transfer - success *)
@@ -323,11 +323,11 @@ let test_update_operator_add_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner3 = List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner1;
@@ -336,8 +336,8 @@ let test_update_operator_add_operator_and_transfer =
       } : FA2_single_asset.TZIP12.operator) : FA2_single_asset.TZIP12.unit_update);
     ] : FA2_single_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source owner2 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner2 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner2;
@@ -346,11 +346,11 @@ let test_update_operator_add_operator_and_transfer =
       } : FA2_single_asset.TZIP12.operator) : FA2_single_asset.TZIP12.unit_update);
     ] : FA2_single_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op3 in
+  let () = Test.Next.State.set_source op3 in
   let transfer_requests = ([
     ({from_=owner1; txs=([{to_=owner2;token_id=0n;amount=0n};{to_=owner3;token_id=0n;amount=0n}] : FA2_single_asset.TZIP12.atomic_trans list)});
     ({from_=owner2; txs=([{to_=owner2;token_id=0n;amount=2n};] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
   ()

--- a/test/fa2/single_asset_jsligo.test.mligo
+++ b/test/fa2/single_asset_jsligo.test.mligo
@@ -20,17 +20,17 @@ module List_helper = struct
 end
 
 let get_initial_storage (a, b, c : nat * nat * nat) =
-  let () = Test.reset_state 6n ([] : tez list) in
+  let () = Test.Next.State.reset 6n ([] : tez list) in
 
-  let owner1 = Test.nth_bootstrap_account 0 in
-  let owner2 = Test.nth_bootstrap_account 1 in
-  let owner3 = Test.nth_bootstrap_account 2 in
+  let owner1 = Test.Next.Account.address 0n in
+  let owner2 = Test.Next.Account.address 1n in
+  let owner3 = Test.Next.Account.address 2n in
 
   let owners = [owner1; owner2; owner3] in
 
-  let op1 = Test.nth_bootstrap_account 3 in
-  let op2 = Test.nth_bootstrap_account 4 in
-  let op3 = Test.nth_bootstrap_account 5 in
+  let op1 = Test.Next.Account.address 3n in
+  let op2 = Test.Next.Account.address 4n in
+  let op3 = Test.Next.Account.address 5n in
 
   let ops = [op1; op2; op3] in
 
@@ -92,18 +92,18 @@ let assert_balances
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in
   let (owner3, balance3) = c in
-  let storage = Test.get_storage contract_address in
+  let storage = Test.Next.Typed_address.get_storage contract_address in
   let ledger = storage.ledger in
   let () = match (Big_map.find_opt owner1 ledger) with
-    Some amt -> assert (amt = balance1)
+    Some amt -> Test.Next.Assert.assert (amt = balance1)
   | None -> failwith "incorret address"
   in
   let () = match (Big_map.find_opt owner2 ledger) with
-    Some amt ->  assert (amt = balance2)
+    Some amt ->  Test.Next.Assert.assert (amt = balance2)
   | None -> failwith "incorret address"
   in
   let () = match (Big_map.find_opt owner3 ledger) with
-    Some amt -> assert (amt = balance3)
+    Some amt -> Test.Next.Assert.assert (amt = balance3)
   | None -> failwith "incorret address"
   in
   ()
@@ -122,10 +122,10 @@ let test_atomic_transfer_success =
     ({from_=owner2; txs=([{to_=owner3;token_id=0n;amount=2n};{to_=owner1;token_id=0n;amount=3n}] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = assert_balances orig.addr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = assert_balances orig.taddr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
   ()
 
 (* 2. transfer failure incorrect operator *)
@@ -140,13 +140,13 @@ let test_atomic_transfer_failure_not_operator =
     ({from_=owner2; txs=([{to_=owner3;token_id=0n;amount=2n};{to_=owner1;token_id=0n;amount=3n}] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op3 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_single_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_single_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* 3. transfer failure insuffient balance *)
@@ -161,13 +161,13 @@ let test_atomic_transfer_failure_not_suffient_balance =
     ({from_=owner2; txs=([{to_=owner3;token_id=0n;amount=2n};{to_=owner1;token_id=0n;amount=3n}] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_single_asset.Errors.ins_balance))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_single_asset.Errors.ins_balance))
   | Fail _ -> failwith "invalid test failure"
 
 (* 4. transfer successful 0 amount & self transfer *)
@@ -182,11 +182,11 @@ let test_atomic_transfer_success_zero_amount_and_self_transfer =
     ({from_=owner2; txs=([{to_=owner2;token_id=0n;amount=2n};] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op1 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
-  let () = assert_balances orig.addr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
+  let () = assert_balances orig.taddr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
   ()
 
 (* 5. transfer failure transitive operators *)
@@ -200,13 +200,13 @@ let test_transfer_failure_transitive_operators =
       ({from_=owner3; txs=([{to_=owner2;token_id=0n;amount=2n};] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let () = Test.set_source op2 in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let () = Test.Next.State.set_source op2 in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_single_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_single_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* Balance of *)
@@ -214,20 +214,20 @@ let test_transfer_failure_transitive_operators =
 (* 6. empty balance of + callback with empty response *)
 let test_empty_transfer_and_balance_of =
   let initial_storage, _owners, _operators = get_initial_storage (10n, 10n, 10n) in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([] : FA2_single_asset.TZIP12.request list);
     callback = callback_contract;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([] : nat list))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([] : nat list))
 
 (* 7. duplicate balance_of requests *)
 let test_balance_of_requests_with_duplicates =
@@ -236,8 +236,8 @@ let test_balance_of_requests_with_duplicates =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let _op1   = List_helper.nth_exn 0 operators in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([
@@ -248,12 +248,12 @@ let test_balance_of_requests_with_duplicates =
     callback = callback_contract;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([10n; 5n; 10n]))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([10n; 5n; 10n]))
 
 (* 8. 0 balance if does not hold any tokens (not in ledger) *)
 let test_balance_of_0_balance_if_address_does_not_hold_tokens =
@@ -262,8 +262,8 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  let callback_contract = Test.to_contract orig_callback.addr in
+  let orig_callback = Test.Next.Originate.contract (contract_of Callback) ([] : nat list) 0tez in
+  let callback_contract = Test.Next.Typed_address.to_contract orig_callback.taddr in
 
   let balance_of_requests = ({
     requests = ([
@@ -274,12 +274,12 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
     callback = callback_contract;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
-  let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Balance_of balance_of_requests) 0tez in
 
-  let callback_storage = Test.get_storage orig_callback.addr in
-  assert (callback_storage = ([10n; 5n; 0n]))
+  let callback_storage = Test.Next.Typed_address.get_storage orig_callback.taddr in
+  Test.Next.Assert.assert (Test.Next.Compare.eq callback_storage ([10n; 5n; 0n]))
 
 (* Update operators *)
 
@@ -290,11 +290,11 @@ let test_update_operator_remove_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner3 = List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Remove_operator ({
         owner    = owner1;
@@ -303,16 +303,16 @@ let test_update_operator_remove_operator_and_transfer =
       } : FA2_single_asset.TZIP12.operator) : FA2_single_asset.TZIP12.unit_update)
     ] : FA2_single_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op1 in
+  let () = Test.Next.State.set_source op1 in
   let transfer_requests = ([
     ({from_=owner1; txs=([{to_=owner2;token_id=0n;amount=0n};{to_=owner3;token_id=0n;amount=0n}] : FA2_single_asset.TZIP12.atomic_trans list)});
     ({from_=owner2; txs=([{to_=owner2;token_id=0n;amount=2n};] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
+  let result = Test.Next.Typed_address.transfer orig.taddr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval FA2_single_asset.Errors.not_operator))
+  | Fail (Rejected (err, _))  -> Test.Next.Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval FA2_single_asset.Errors.not_operator))
   | Fail _ -> failwith "invalid test failure"
 
 (* 10. Add operator & do transfer - success *)
@@ -322,11 +322,11 @@ let test_update_operator_add_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner3 = List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
+  let orig = Test.Next.Originate.contract (contract_of FA2_single_asset) initial_storage 0tez in
 
 
-  let () = Test.set_source owner1 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner1 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner1;
@@ -335,8 +335,8 @@ let test_update_operator_add_operator_and_transfer =
       } : FA2_single_asset.TZIP12.operator) : FA2_single_asset.TZIP12.unit_update);
     ] : FA2_single_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source owner2 in
-  let _ = Test.transfer_exn orig.addr
+  let () = Test.Next.State.set_source owner2 in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr
     (Update_operators ([
       (Add_operator ({
         owner    = owner2;
@@ -345,12 +345,12 @@ let test_update_operator_add_operator_and_transfer =
       } : FA2_single_asset.TZIP12.operator) : FA2_single_asset.TZIP12.unit_update);
     ] : FA2_single_asset.TZIP12.update_operators)) 0tez in
 
-  let () = Test.set_source op3 in
+  let () = Test.Next.State.set_source op3 in
   let transfer_requests = ([
     ({from_=owner1; txs=([{to_=owner2;token_id=0n;amount=0n};{to_=owner3;token_id=0n;amount=0n}] : FA2_single_asset.TZIP12.atomic_trans list)});
     ({from_=owner2; txs=([{to_=owner2;token_id=0n;amount=2n};] : FA2_single_asset.TZIP12.atomic_trans list)});
   ] : FA2_single_asset.TZIP12.transfer)
   in
-  let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
+  let _ = Test.Next.Typed_address.transfer_exn orig.taddr (Transfer transfer_requests) 0tez in
   ()
 

--- a/test/helpers/nft_helpers.jsligo
+++ b/test/helpers/nft_helpers.jsligo
@@ -1,0 +1,124 @@
+export #import "../../lib/fa2/nft/nft.impl.jsligo" "FA2_NFT"
+
+export function get_initial_storage () {
+  Test.Next.State.reset(8n, [
+    1000000tez,
+    1000000tez,
+    1000000tez,
+    1000000tez,
+    1000000tez,
+    1000000tez,
+    1000000tez,
+    1000000tez,
+  ] as list<tez>);
+
+  const baker = Test.Next.Account.address(7n);
+  Test.Next.State.set_baker(baker);
+
+  const owner1 = Test.Next.Account.address(0n);
+  const owner2 = Test.Next.Account.address(1n);
+  const owner3 = Test.Next.Account.address(2n);
+  const owner4 = Test.Next.Account.address(6n);
+
+  const owners = list([owner1, owner2, owner3, owner4]);
+
+  const op1 = Test.Next.Account.address(3n);
+  const op2 = Test.Next.Account.address(4n);
+  const op3 = Test.Next.Account.address(5n);
+
+  const ops = list([op1, op2, op3]);
+
+  const ledger = Big_map.literal([
+    [1n, owner1],
+    [2n, owner2],
+    [3n, owner3],
+    [4n, owner4],
+    [5n, owner4]
+  ]);
+
+  const operators = Big_map.literal([
+    [[owner1, op1], Set.literal([1n])],
+    [[owner2, op1], Set.literal([2n])],
+    [[owner3, op1], Set.literal([3n])],
+    [[op1   , op3], Set.literal([1n])],
+    [[owner4, op1], Set.literal([4n, 5n])]
+  ]);
+
+  const token_metadata = Big_map.literal([
+    [1n, ({token_id: 1n, token_info: Map.empty as map<string, bytes>}
+          as FA2_NFT.TZIP12.tokenMetadataData)],
+    [2n, ({token_id: 2n, token_info: Map.empty as map<string, bytes>}
+          as FA2_NFT.TZIP12.tokenMetadataData)],
+    [3n, ({token_id: 3n, token_info: Map.empty as map<string, bytes>}
+          as FA2_NFT.TZIP12.tokenMetadataData)],
+    [4n, ({token_id: 3n, token_info: Map.empty as map<string, bytes>}
+          as FA2_NFT.TZIP12.tokenMetadataData)],
+    [5n, ({token_id: 3n, token_info: Map.empty as map<string, bytes>}
+          as FA2_NFT.TZIP12.tokenMetadataData)]
+  ]) as FA2_NFT.TZIP12.tokenMetadata;
+
+  const metadata = Big_map.literal([
+    ["", bytes`tezos-storage:data`],
+    ["data", bytes`{
+	"name":"FA2",
+	"description":"Example FA2 implementation",
+	"version":"0.1.0",
+	"license":{"name":"MIT"},
+	"authors":["Benjamin Fuentes<benjamin.fuentes@marigold.dev>"],
+	"homepage":"",
+	"source":{"tools":["Ligo"], "location":"https://github.com/ligolang/contract-catalogue/tree/main/lib/fa2"},
+	"interfaces":["TZIP-012"],
+	"errors":[],
+	"views":[]
+
+}`]]);
+
+  const initial_storage : FA2_NFT.storage = {
+    ledger         : ledger,
+    token_metadata : token_metadata,
+    operators      : operators,
+    metadata       : metadata
+  };
+
+  return [initial_storage, owners, ops];
+}
+
+export function assert_balances
+  (contract_address:
+     typed_address <parameter_of FA2_NFT, FA2_NFT.storage>,
+   [a, b, c]:
+     [[address, nat], [address, nat], [address, nat]]) {
+  const [owner1, token_id_1] = a;
+  const [owner2, token_id_2] = b;
+  const [owner3, token_id_3] = c;
+  const storage = Test.Next.Typed_address.get_storage(contract_address);
+  const ledger = storage.ledger;
+  const _x =
+    match(Big_map.find_opt(token_id_1, ledger)) {
+      when(Some(amt)) : Assert.assert(amt == owner1);
+      when(None) : Test.Next.Assert.failwith("incorrect address");
+    };
+
+  const _y =
+    match(Big_map.find_opt(token_id_2, ledger)) {
+      when(Some(amt)) : Assert.assert (amt == owner2);
+      when(None) : Test.Next.Assert.failwith("incorrect address");
+    };
+
+  const _z =
+    match(Big_map.find_opt(token_id_3, ledger)) {
+      when(Some(amt)) : Assert.assert (amt == owner3);
+      when(None) : Test.Next.Assert.failwith("incorrect address");
+    };
+
+  return unit;
+};
+
+export const assert_error =
+  (result: test_exec_result, error : FA2_NFT.Errors.t) =>
+  match(result) {
+    when(Success(_)) : Test.Next.Assert.failwith("This test should fail");
+    when(Fail(Rejected(err, _))) :
+      Assert.assert (Test.Next.Compare.eq(err, Test.Next.Michelson.eval(error)))
+    when(Fail(_)) : Test.Next.Assert.failwith("invalid test failure")
+  };

--- a/test/helpers/nft_helpers.mligo
+++ b/test/helpers/nft_helpers.mligo
@@ -1,7 +1,7 @@
-#import "../../lib/fa2/nft/nft.impl.mligo" "FA2_NFT"
+[@public] #import "../../lib/fa2/nft/nft.impl.mligo" "FA2_NFT"
 
 let get_initial_storage () =
-  let () = Test.reset_state 8n ([
+  let () = Test.Next.State.reset 8n ([
     1000000tez;
     1000000tez;
     1000000tez;
@@ -12,19 +12,19 @@ let get_initial_storage () =
     1000000tez;
   ] : tez list) in
 
-  let baker = Test.nth_bootstrap_account 7 in
-  let () = Test.set_baker baker in
+  let baker = Test.Next.Account.address 7n in
+  let () = Test.Next.State.set_baker baker in
 
-  let owner1 = Test.nth_bootstrap_account 0 in
-  let owner2 = Test.nth_bootstrap_account 1 in
-  let owner3 = Test.nth_bootstrap_account 2 in
-  let owner4 = Test.nth_bootstrap_account 6 in
+  let owner1 = Test.Next.Account.address 0n in
+  let owner2 = Test.Next.Account.address 1n in
+  let owner3 = Test.Next.Account.address 2n in
+  let owner4 = Test.Next.Account.address 6n in
 
   let owners = [owner1; owner2; owner3; owner4] in
 
-  let op1 = Test.nth_bootstrap_account 3 in
-  let op2 = Test.nth_bootstrap_account 4 in
-  let op3 = Test.nth_bootstrap_account 5 in
+  let op1 = Test.Next.Account.address 3n in
+  let op2 = Test.Next.Account.address 4n in
+  let op3 = Test.Next.Account.address 5n in
 
   let ops = [op1; op2; op3] in
 
@@ -89,24 +89,24 @@ let assert_balances
   let (owner1, token_id_1) = a in
   let (owner2, token_id_2) = b in
   let (owner3, token_id_3) = c in
-  let storage = Test.get_storage contract_address in
+  let storage = Test.Next.Typed_address.get_storage contract_address in
   let ledger = storage.ledger in
   let () = match (Big_map.find_opt token_id_1 ledger) with
-    Some amt -> assert (amt = owner1)
-  | None -> Test.failwith "incorret address"
+    Some amt -> Assert.assert (amt = owner1)
+  | None -> Test.Next.Assert.failwith "incorrect address"
   in
   let () = match (Big_map.find_opt token_id_2 ledger) with
-    Some amt ->  assert (amt = owner2)
-  | None -> Test.failwith "incorret address"
+    Some amt ->  Assert.assert (amt = owner2)
+  | None -> Test.Next.Assert.failwith "incorrect address"
   in
   let () = match (Big_map.find_opt token_id_3 ledger) with
-    Some amt -> assert (amt = owner3)
-  | None -> Test.failwith "incorret address"
+    Some amt -> Assert.assert (amt = owner3)
+  | None -> Test.Next.Assert.failwith "incorrect address"
   in
   ()
 
 let assert_error (result : test_exec_result) (error : FA2_NFT.Errors.t) =
   match result with
-    Success _ -> Test.failwith "This test should fail"
-  | Fail (Rejected (err, _))  -> assert (Test.michelson_equal err (Test.eval error))
-  | Fail _ -> Test.failwith "invalid test failure"
+    Success _ -> Test.Next.Assert.failwith "This test should fail"
+  | Fail (Rejected (err, _))  -> Assert.assert (Test.Next.Compare.eq err (Test.Next.Michelson.eval error))
+  | Fail _ -> Test.Next.Assert.failwith "invalid test failure"


### PR DESCRIPTION
- [x] Up to 1.7
- [x] Fix the warning about ticket variable used more than once (replaced the syntax sugar with `List.cons` call
- [x] Removed the Makefile targets relative to scripts, as they have been removed currently until https://github.com/ligolang/contract-catalogue/issues/40 is resolved
- [x] Removed the `@layout` annotations as `comb` is now the default
- [x] (Auto) Formatting